### PR TITLE
feat(wifi): implement simultaneous AP + Client dual-mode support

### DIFF
--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -509,7 +509,7 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
             if (dualMode && isAPInterface) {
                 try {
                     // Create new connection with nmcli dynamically
-                    // Connection name uses the SSID (e.g., HALOS-B782)
+                    // Connection name uses the SSID (e.g., hostname-B782)
                     const args = [
                         "connection", "add",
                         "type", "wifi",
@@ -610,7 +610,7 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                         <FormHelperText>
                             <HelperText>
                                 <HelperTextItem>
-                                    {_("Default: HALOS-{last 4 chars of MAC address}")}
+                                    {_("Default: {hostname}-{last 4 chars of MAC}")}
                                 </HelperTextItem>
                             </HelperText>
                         </FormHelperText>
@@ -789,17 +789,23 @@ function getMACAddress(dev) {
 }
 
 // Helper function to generate default SSID for Access Point
+// Uses system hostname with MAC suffix for uniqueness
 function generateDefaultSSID(dev) {
     const mac = getMACAddress(dev);
-    if (!mac) return "HALOS-AP";
+    // Get hostname, fallback to generic prefix if not available
+    const hostname = cockpit.localStorage.getItem("HostnameOverride") ||
+                     window.location.hostname?.split('.')[0] ||
+                     "WiFi";
+
+    if (!mac) return `${hostname}-AP`;
 
     // Clean MAC address (remove colons) and validate length
     const macClean = mac.replace(/:/g, '').toUpperCase();
-    if (macClean.length < 4) return "HALOS-AP";
+    if (macClean.length < 4) return `${hostname}-AP`;
 
-    // Get last 4 characters of MAC address
+    // Get last 4 characters of MAC address for uniqueness
     const macSuffix = macClean.slice(-4);
-    return `HALOS-${macSuffix}`;
+    return `${hostname}-${macSuffix}`;
 }
 
 // Ghost settings for "Add WiFi" action (Client mode)


### PR DESCRIPTION
## Summary

- Implement virtual interface creation (`wlan0ap`) for dual-mode WiFi operation
- Enable simultaneous Access Point and Client modes on the same hardware
- Dynamic connection creation without requiring pre-existing profiles
- Fix AP disable button and client list for dual-mode scenarios

## Changes

- **Virtual interface**: Creates `<iface>ap` interface (e.g., `wlan0ap`) for AP mode
- **Dynamic connections**: Creates AP connection on-the-fly with HALOS-xxxx SSID
- **Dual-mode detection**: Properly detect and display both AP and Client states
- **Disable fix**: Use correct activeConnection for deactivation in dual-mode
- **Client list fix**: Read leases from correct interface, use `superuser: "require"`

## Dependencies

Requires NetworkManager dispatcher script for NAT rules (see hatlabs/halos-pi-gen#26)

## Test plan

- [x] Enable AP mode while connected as client
- [x] Verify both modes active simultaneously  
- [x] Test internet access through AP
- [x] Verify connected clients list shows devices
- [x] Test disable button works correctly
- [x] Verify NAT rules cleaned up on disable

Closes hatlabs/cockpit-networkmanager-halos#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)