### PR TITLE
wifi: gate admin actions in Cockpit Limited Access mode

### DIFF
--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -50,6 +50,11 @@ const _ = cockpit.gettext;
 // NetworkManager device state constants
 const NM_DEVICE_STATE_UNAVAILABLE = 20;
 
+// N_ marks a string for gettext extraction without translating at definition
+// time. `_(N_("..."))` translates at call time so the same string can be
+// referenced from multiple call sites.
+function N_(s) { return s }
+
 // Tooltip shown on admin-gated controls in Cockpit Limited Access mode.
 const ADMIN_REQUIRED_TOOLTIP = N_("Administrative access required");
 
@@ -93,11 +98,6 @@ const AdminGatedButton = ({ isAdminRequired, isAriaDisabled, children, ...props 
     }
     return button;
 };
-
-// N_ marks a string for gettext extraction without translating at definition
-// time. `_(N_("..."))` translates at call time so the same string can be
-// referenced from multiple call sites.
-function N_(s) { return s }
 
 // Parse security flags from AccessPoint properties
 function parseSecurityFlags(flags, wpaFlags, rsnFlags) {
@@ -157,9 +157,13 @@ const SecurityBadge = ({ security }) => {
 
 // WiFi Network List Item
 const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected, isAdminRequired }) => {
+    // Suppress the action when admin is required but keep the onClick handler
+    // attached so the ListItem stays focusable and the Tooltip below triggers
+    // on keyboard focus, not just mouse hover.
+    const handleClick = isAdminRequired ? e => e.preventDefault() : onClick;
     const item = (
         <ListItem
-            onClick={isAdminRequired ? undefined : onClick}
+            onClick={handleClick}
             style={{
                 cursor: isAdminRequired ? 'not-allowed' : 'pointer',
                 opacity: isAdminRequired ? 0.6 : 1,
@@ -1059,7 +1063,7 @@ const WiFiHiddenDialog = ({ dev }) => {
 };
 
 // Saved Networks List Component
-const WiFiSavedNetworks = ({ dev, model }) => {
+const WiFiSavedNetworks = ({ dev, model, isAdminRequired }) => {
     const [savedNetworks, setSavedNetworks] = useState([]);
     const [error, setError] = useState(null);
 
@@ -1190,28 +1194,36 @@ const WiFiSavedNetworks = ({ dev, model }) => {
                                     </FlexItem>
                                     <FlexItem>
                                         <span style={{ display: "inline-flex", gap: "0" }}>
-                                            <Button
+                                            <AdminGatedButton
                                                 variant="plain"
                                                 aria-label={_("Move up")}
-                                                isDisabled={index === 0}
+                                                isAriaDisabled={index === 0}
+                                                isAdminRequired={isAdminRequired}
                                                 onClick={() => handleMoveUp(connection, index)}
                                             >
                                                 <AngleUpIcon />
-                                            </Button>
-                                            <Button
+                                            </AdminGatedButton>
+                                            <AdminGatedButton
                                                 variant="plain"
                                                 aria-label={_("Move down")}
-                                                isDisabled={index === savedNetworks.length - 1}
+                                                isAriaDisabled={index === savedNetworks.length - 1}
+                                                isAdminRequired={isAdminRequired}
                                                 onClick={() => handleMoveDown(connection, index)}
                                             >
                                                 <AngleDownIcon />
-                                            </Button>
+                                            </AdminGatedButton>
                                         </span>
                                     </FlexItem>
                                     <FlexItem>
                                         <KebabDropdown
                                             dropdownItems={[
-                                                <DropdownItem key="forget" onClick={() => handleForget(connection)} isDanger>
+                                                <DropdownItem
+                                                    key="forget"
+                                                    onClick={() => handleForget(connection)}
+                                                    isAriaDisabled={isAdminRequired}
+                                                    tooltipProps={isAdminRequired ? { content: _(ADMIN_REQUIRED_TOOLTIP) } : undefined}
+                                                    isDanger
+                                                >
                                                     {_("Forget")}
                                                 </DropdownItem>
                                             ]}
@@ -2400,7 +2412,7 @@ export const WiFiPage = ({ iface, dev }) => {
                     />
                 </CardBody>
             </Card>
-            <WiFiSavedNetworks dev={dev} model={model} />
+            <WiFiSavedNetworks dev={dev} model={model} isAdminRequired={isAdminRequired} />
         </>
     );
 };

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -36,6 +36,7 @@ import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdow
 import { AngleUpIcon, AngleDownIcon, StarIcon } from '@patternfly/react-icons';
 import { KebabDropdown } from 'cockpit-components-dropdown';
 import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput/index.js';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/index.js';
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useDialogs } from 'dialogs.jsx';
@@ -48,6 +49,55 @@ const _ = cockpit.gettext;
 
 // NetworkManager device state constants
 const NM_DEVICE_STATE_UNAVAILABLE = 20;
+
+// Tooltip shown on admin-gated controls in Cockpit Limited Access mode.
+const ADMIN_REQUIRED_TOOLTIP = N_("Administrative access required");
+
+// Reactive accessor for Cockpit's administrative-access state. Returns
+// { allowed: boolean | null }. Treat `null` (unresolved) as "not yet
+// allowed" so the brief permission-resolution race window stays gated.
+// Falls back to `allowed: true` when running outside Cockpit (test runs
+// without an explicit mock).
+const useAdminPermission = () => {
+    const [allowed, setAllowed] = useState(null);
+
+    useEffect(() => {
+        if (typeof cockpit === "undefined" || !cockpit.permission) {
+            setAllowed(true);
+            return;
+        }
+        const permission = cockpit.permission({ admin: true });
+        const update = () => setAllowed(permission.allowed);
+        update();
+        permission.addEventListener("changed", update);
+        return () => {
+            permission.removeEventListener("changed", update);
+            permission.close();
+        };
+    }, []);
+
+    return { allowed };
+};
+
+// PatternFly Button wrapper that uses `isAriaDisabled` (suppresses
+// onClick via preventDefault) when admin is required and wraps the
+// disabled button in a Tooltip explaining the elevation requirement.
+const AdminGatedButton = ({ isAdminRequired, isAriaDisabled, children, ...props }) => {
+    const button = (
+        <Button {...props} isAriaDisabled={isAdminRequired || isAriaDisabled}>
+            {children}
+        </Button>
+    );
+    if (isAdminRequired) {
+        return <Tooltip content={_(ADMIN_REQUIRED_TOOLTIP)}>{button}</Tooltip>;
+    }
+    return button;
+};
+
+// N_ marks a string for gettext extraction without translating at definition
+// time. `_(N_("..."))` translates at call time so the same string can be
+// referenced from multiple call sites.
+function N_(s) { return s }
 
 // Parse security flags from AccessPoint properties
 function parseSecurityFlags(flags, wpaFlags, rsnFlags) {
@@ -106,9 +156,16 @@ const SecurityBadge = ({ security }) => {
 };
 
 // WiFi Network List Item
-const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected }) => {
-    return (
-        <ListItem onClick={onClick} style={{ cursor: 'pointer' }}>
+const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected, isAdminRequired }) => {
+    const item = (
+        <ListItem
+            onClick={isAdminRequired ? undefined : onClick}
+            style={{
+                cursor: isAdminRequired ? 'not-allowed' : 'pointer',
+                opacity: isAdminRequired ? 0.6 : 1,
+            }}
+            aria-disabled={isAdminRequired || undefined}
+        >
             <Flex alignItems={{ default: 'alignItemsCenter' }}>
                 <FlexItem flex={{ default: 'flex_1' }}>
                     <span style={{ fontWeight: isConnected ? 'bold' : 'normal' }}>
@@ -125,10 +182,14 @@ const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected }) => {
             </Flex>
         </ListItem>
     );
+    if (isAdminRequired) {
+        return <Tooltip content={_(ADMIN_REQUIRED_TOOLTIP)}>{item}</Tooltip>;
+    }
+    return item;
 };
 
 // WiFi Network List Component
-const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new Set(), connectedSSID }) => {
+const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new Set(), connectedSSID, isAdminRequired }) => {
     if (accessPoints.length === 0 && !scanning) {
         return (
             <EmptyState>
@@ -171,6 +232,7 @@ const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new S
                     onClick={() => onConnect(ap)}
                     isSaved={savedSSIDs.has(ap.ssid)}
                     isConnected={ap.ssid === connectedSSID}
+                    isAdminRequired={isAdminRequired}
                 />
             ))}
         </List>
@@ -1291,7 +1353,7 @@ const WiFiAPClientList = ({ iface }) => {
 };
 
 // WiFi AP Configuration Status Component
-export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canEnableAP, onEnableAP, deviceUnavailable }) => {
+export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canEnableAP, onEnableAP, deviceUnavailable, isAdminRequired }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
     const [error, setError] = useState(null);
@@ -1359,13 +1421,14 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                 <CardHeader actions={canEnableAP
                     ? {
                         actions: (
-                            <Button
+                            <AdminGatedButton
                                 variant="primary"
                                 onClick={onEnableAP}
-                                isDisabled={deviceUnavailable}
+                                isAriaDisabled={deviceUnavailable}
+                                isAdminRequired={isAdminRequired}
                             >
                                 {_("Enable")}
-                            </Button>
+                            </AdminGatedButton>
                         )
                     }
                     : undefined}>
@@ -1385,12 +1448,21 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
             <CardHeader actions={{
                 actions: (
                     <>
-                        <Button variant="secondary" onClick={handleConfigure} style={{ marginRight: "var(--pf-global--spacer--sm)" }}>
+                        <AdminGatedButton
+                            variant="secondary"
+                            onClick={handleConfigure}
+                            isAdminRequired={isAdminRequired}
+                            style={{ marginRight: "var(--pf-global--spacer--sm)" }}
+                        >
                             {_("Configure")}
-                        </Button>
-                        <Button variant="danger" onClick={handleDisable}>
+                        </AdminGatedButton>
+                        <AdminGatedButton
+                            variant="danger"
+                            onClick={handleDisable}
+                            isAdminRequired={isAdminRequired}
+                        >
                             {_("Disable")}
-                        </Button>
+                        </AdminGatedButton>
                     </>
                 )
             }}>
@@ -1763,6 +1835,8 @@ function getWiFiConnectionStates(dev, model) {
 export const WiFiPage = ({ iface, dev }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
+    const { allowed: isAdminAllowed } = useAdminPermission();
+    const isAdminRequired = isAdminAllowed !== true;
     const [scanning, setScanning] = useState(false);
     const [accessPoints, setAccessPoints] = useState([]);
     const [error, setError] = useState(null);
@@ -2216,15 +2290,16 @@ export const WiFiPage = ({ iface, dev }) => {
     // Action links for WiFi unavailable alert (only show enable button if rfkill blocked)
     const wifiUnavailableActionLinks = rfkillBlocked
         ? (
-            <Button
+            <AdminGatedButton
                 variant="link"
                 isInline
                 onClick={handleEnableWifi}
                 isLoading={enablingWifi}
-                isDisabled={enablingWifi}
+                isAriaDisabled={enablingWifi}
+                isAdminRequired={isAdminRequired}
             >
                 {enablingWifi ? _("Enabling...") : _("Enable WiFi")}
-            </Button>
+            </AdminGatedButton>
         )
         : undefined;
 
@@ -2267,6 +2342,7 @@ export const WiFiPage = ({ iface, dev }) => {
                     canEnableAP={canEnableAP}
                     onEnableAP={handleEnableAP}
                     deviceUnavailable={deviceUnavailable}
+                    isAdminRequired={isAdminRequired}
                 />
             </div>
 
@@ -2286,9 +2362,14 @@ export const WiFiPage = ({ iface, dev }) => {
                             </Button>
                         </FlexItem>
                         <FlexItem>
-                            <Button variant="secondary" onClick={handleConnectHidden} isDisabled={deviceUnavailable}>
+                            <AdminGatedButton
+                                variant="secondary"
+                                onClick={handleConnectHidden}
+                                isAriaDisabled={deviceUnavailable}
+                                isAdminRequired={isAdminRequired}
+                            >
                                 {_("Connect to Hidden Network")}
-                            </Button>
+                            </AdminGatedButton>
                         </FlexItem>
                     </Flex>
                 </CardHeader>
@@ -2315,6 +2396,7 @@ export const WiFiPage = ({ iface, dev }) => {
                         scanning={scanning}
                         savedSSIDs={savedSSIDs}
                         connectedSSID={connectedSSID}
+                        isAdminRequired={isAdminRequired}
                     />
                 </CardBody>
             </Card>


### PR DESCRIPTION
## Why

Without admin gating, the HaLOS WiFi UI in `pkg/networkmanager/wifi.jsx`
presents fully-clickable affordances even when the user is in Cockpit's
Limited Access mode. The six `superuser: 'require'` spawns at
`wifi.jsx` ~427/431/546/549/1190/1890 and the
`cockpit.file(..., { superuser: 'require' })` dnsmasq-leases read all
hard-fail before NetworkManager is even consulted, leaving the user
with no signal as to why "Enable AP", "Connect to Hidden Network",
"Enable WiFi", or per-network "Connect" silently no-ops.

Identified during the cross-module audit in `halos-org/halos#121`;
addresses `halos-org/cockpit-networkmanager-halos#13` (packaging
side).

## What changed (HaLOS WiFi surface only)

Per the audit's recommendation: scope is limited to `wifi.jsx`.
Upstream files (`firewall.jsx`, `firewall-switch.jsx`,
`firewall-client.js`, `network-interface.jsx`, `interfaces.js`,
`dialogs-common.jsx`) are **not** touched — they already have
working `readonly` / `show_unexpected_error` paths, and modifying
them would complicate future upstream rebases.

### Inline shared primitives (file-scoped)

- **`useAdminPermission` hook** wrapping `cockpit.permission({ admin: true })`.
  Returns `{ allowed }`. Treats `null` (unresolved) as "not yet
  allowed" so the brief permission-resolution race window stays
  gated. Falls back to `allowed: true` when running outside Cockpit
  (test runs without an explicit mock).
- **`AdminGatedButton`** wrapper that uses PatternFly's
  `isAriaDisabled` (suppresses `onClick` via `preventDefault`) when
  admin is required, and wraps the disabled button in a `Tooltip`
  reading "Administrative access required". Tooltip text marked for
  i18n via `N_("...")` + `_(N_(...))`.

### Gated sites

- `WiFiAPConfig`: Enable / Configure / Disable buttons gated via
  `AdminGatedButton`.
- `WiFiPage`: the action link in the "WiFi disabled" alert (rfkill
  unblock = `Enable WiFi`) gated.
- `WiFiPage`: `Connect to Hidden Network` button gated.
- `WiFiNetworkList` propagates `isAdminRequired` to each
  `WiFiNetworkItem`. Items get `aria-disabled`, `cursor: not-allowed`,
  dimmed opacity (0.6), and a Tooltip; their `onClick` is suppressed
  when admin is required.
- `Scan` is not gated — it is a read-only operation in our usage.

### Deliberately *not* changed: `handleDisable` "swallow"

The audit flagged `WiFiAPConfig.handleDisable` (`wifi.jsx:1308–1319`)
as a swallow point. On closer reading the code is correct: `setError`
is called on the parent `WiFiAPConfig`, which renders the error in
its own inline `<Alert>`. Closing the confirmation dialog via
`Dialogs.close()` does not unmount `WiFiAPConfig`, so the error
surfaces normally. No change made.

## Verification

- `npm run eslint pkg/networkmanager/wifi.jsx` clean.
- `node build.js networkmanager` builds successfully.
- Tests not added: the existing `test-wifi-components.js` /
  `test-wifi-hooks.js` qunit harness mocks `model` / `manager` /
  `dev` / `settings` objects but not `cockpit.permission`; building
  out that mocking is its own piece of work and the audit
  explicitly deferred it. Manual verification on a HALPI2 device:
  with Limited Access banner visible, AP Enable / Configure /
  Disable, Enable WiFi, Connect to Hidden Network, and per-network
  Connect are all visibly disabled with the "Administrative access
  required" tooltip. Elevation removes the gating reactively.

## Decisions matching the pilot

- `permission().allowed === null` → admin-required.
- Disable + tooltip rather than hide. Discoverability matters.
- PatternFly v6 `isAriaDisabled` suppresses click via
  `preventDefault` (verified in source by the pilot).

## Refs

- Cross-module audit: halos-org/halos#121
- Pilot: halos-org/cockpit-container-apps#80
- Packaging-side issue: halos-org/cockpit-networkmanager-halos#13
- Pattern doc:
  `docs/solutions/best-practices/2026-05-28-cockpit-module-admin-gating-and-error-surfacing.md`
  (in the halos workspace)
