### PR TITLE
networkmanager: gate WiFi controls when admin access is unavailable

### DIFF
--- a/files.js
+++ b/files.js
@@ -88,6 +88,7 @@ const info = {
         "networkmanager/test-utils.js",
         "networkmanager/test-wifi-hooks.js",
         "networkmanager/test-wifi-components.js",
+        "networkmanager/test-wifi-admin-gating.js",
 
         "shell/machines/test-machines.js",
 

--- a/pkg/networkmanager/test-wifi-admin-gating.js
+++ b/pkg/networkmanager/test-wifi-admin-gating.js
@@ -24,43 +24,130 @@
  * Limited Access mode, where `superuser: "require"` spawns and
  * Polkit-restricted DBus calls would otherwise fail silently after the
  * user clicks a control.
- *
- * Per pilot decisions (cockpit-container-apps#80) and audit
- * (halos-org/halos#121): treat `cockpit.permission({admin:true})`
- * `allowed === null` (subscription unresolved) as admin-required so the
- * loading window is gated, not just the resolved-denied state.
  */
 
 import QUnit from "qunit-tests";
-import { isAdminRequired, ADMIN_REQUIRED_TOOLTIP } from "./wifi-admin-gating";
+import {
+    isAdminRequired,
+    subscribeAdminPermission,
+    ADMIN_REQUIRED_TOOLTIP,
+} from "./wifi-admin-gating";
+
+// ============================================================================
+// isAdminRequired predicate
+// ============================================================================
+//
+// Pilot decision (cockpit-container-apps#80): treat the loading window
+// (allowed === null) as gated so controls don't briefly flash enabled
+// during initial page load.
 
 QUnit.module("isAdminRequired");
 
-QUnit.test("gates while the permission subscription is unresolved (allowed === null)", function(assert) {
-    assert.strictEqual(isAdminRequired({ allowed: null }), true);
-});
-
-QUnit.test("gates when admin permission is denied (allowed === false)", function(assert) {
-    assert.strictEqual(isAdminRequired({ allowed: false }), true);
-});
-
-QUnit.test("does not gate when admin permission is granted (allowed === true)", function(assert) {
-    assert.strictEqual(isAdminRequired({ allowed: true }), false);
-});
-
-QUnit.test("gates when the permission handle itself is null (no subscription)", function(assert) {
+QUnit.test("gates while the permission subscription is unresolved (null)", function(assert) {
     assert.strictEqual(isAdminRequired(null), true);
 });
 
-QUnit.test("gates when the permission handle is undefined", function(assert) {
+QUnit.test("gates when admin permission is denied (false)", function(assert) {
+    assert.strictEqual(isAdminRequired(false), true);
+});
+
+QUnit.test("does not gate when admin permission is granted (true)", function(assert) {
+    assert.strictEqual(isAdminRequired(true), false);
+});
+
+QUnit.test("gates when no permission value has been threaded through (undefined)", function(assert) {
     assert.strictEqual(isAdminRequired(undefined), true);
 });
 
+// ============================================================================
+// subscribeAdminPermission
+// ============================================================================
+
+function makeFakePermission(initialAllowed) {
+    const listeners = [];
+    return {
+        allowed: initialAllowed,
+        addEventListener(event, fn) {
+            if (event === "changed") listeners.push(fn);
+        },
+        removeEventListener(event, fn) {
+            if (event !== "changed") return;
+            const idx = listeners.indexOf(fn);
+            if (idx >= 0) listeners.splice(idx, 1);
+        },
+        // Test-only: fire the change event after mutating .allowed.
+        _fire() { for (const fn of listeners) fn(); },
+        _listenerCount() { return listeners.length },
+        close() { this._closed = true },
+    };
+}
+
+QUnit.module("subscribeAdminPermission");
+
+QUnit.test("resolves to true when cockpit is unavailable (dev/test harness)", function(assert) {
+    const calls = [];
+    const cleanup = subscribeAdminPermission(null, value => calls.push(value));
+    assert.deepEqual(calls, [true]);
+    assert.strictEqual(typeof cleanup, "function");
+    cleanup(); // should be a no-op, must not throw
+});
+
+QUnit.test("resolves to true when cockpit lacks a permission() function", function(assert) {
+    const calls = [];
+    subscribeAdminPermission({}, value => calls.push(value));
+    assert.deepEqual(calls, [true]);
+});
+
+QUnit.test("emits the initial permission.allowed value synchronously", function(assert) {
+    const permission = makeFakePermission(false);
+    const cockpitStub = { permission: () => permission };
+    const calls = [];
+    subscribeAdminPermission(cockpitStub, value => calls.push(value));
+    assert.deepEqual(calls, [false]);
+});
+
+QUnit.test("emits subsequent transitions via the 'changed' event", function(assert) {
+    const permission = makeFakePermission(null);
+    const cockpitStub = { permission: () => permission };
+    const calls = [];
+    subscribeAdminPermission(cockpitStub, value => calls.push(value));
+    permission.allowed = true;
+    permission._fire();
+    permission.allowed = false;
+    permission._fire();
+    assert.deepEqual(calls, [null, true, false]);
+});
+
+QUnit.test("cleanup removes the listener so post-unmount events are ignored", function(assert) {
+    const permission = makeFakePermission(true);
+    const cockpitStub = { permission: () => permission };
+    const calls = [];
+    const cleanup = subscribeAdminPermission(cockpitStub, value => calls.push(value));
+    cleanup();
+    assert.strictEqual(permission._listenerCount(), 0);
+    permission.allowed = false;
+    permission._fire();
+    assert.deepEqual(calls, [true]);
+});
+
+QUnit.test("cleanup calls permission.close() when available", function(assert) {
+    const permission = makeFakePermission(true);
+    const cockpitStub = { permission: () => permission };
+    const cleanup = subscribeAdminPermission(cockpitStub, () => {});
+    cleanup();
+    assert.strictEqual(permission._closed, true);
+});
+
+// ============================================================================
+// ADMIN_REQUIRED_TOOLTIP
+// ============================================================================
+
 QUnit.module("ADMIN_REQUIRED_TOOLTIP");
 
-QUnit.test("exposes the canonical cross-module tooltip text", function(assert) {
-    // Matches the AdminGatedButton convention documented in
-    // docs/solutions/best-practices/2026-05-28-cockpit-module-admin-gating-and-error-surfacing.md
+QUnit.test("matches the cross-module canonical tooltip text", function(assert) {
+    // Pins the source string so a rename here forces an audit of the JSX
+    // call site (wifi-admin-gated-button.jsx) which uses the same literal
+    // wrapped in `_("...")` for xgettext extraction.
     assert.strictEqual(ADMIN_REQUIRED_TOOLTIP, "Administrative access required");
 });
 

--- a/pkg/networkmanager/test-wifi-admin-gating.js
+++ b/pkg/networkmanager/test-wifi-admin-gating.js
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2026 Hat Labs
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Unit tests for WiFi admin-gating helpers.
+ *
+ * Pins down the contract used to disable WiFi controls in Cockpit's
+ * Limited Access mode, where `superuser: "require"` spawns and
+ * Polkit-restricted DBus calls would otherwise fail silently after the
+ * user clicks a control.
+ *
+ * Per pilot decisions (cockpit-container-apps#80) and audit
+ * (halos-org/halos#121): treat `cockpit.permission({admin:true})`
+ * `allowed === null` (subscription unresolved) as admin-required so the
+ * loading window is gated, not just the resolved-denied state.
+ */
+
+import QUnit from "qunit-tests";
+import { isAdminRequired, ADMIN_REQUIRED_TOOLTIP } from "./wifi-admin-gating";
+
+QUnit.module("isAdminRequired");
+
+QUnit.test("gates while the permission subscription is unresolved (allowed === null)", function(assert) {
+    assert.strictEqual(isAdminRequired({ allowed: null }), true);
+});
+
+QUnit.test("gates when admin permission is denied (allowed === false)", function(assert) {
+    assert.strictEqual(isAdminRequired({ allowed: false }), true);
+});
+
+QUnit.test("does not gate when admin permission is granted (allowed === true)", function(assert) {
+    assert.strictEqual(isAdminRequired({ allowed: true }), false);
+});
+
+QUnit.test("gates when the permission handle itself is null (no subscription)", function(assert) {
+    assert.strictEqual(isAdminRequired(null), true);
+});
+
+QUnit.test("gates when the permission handle is undefined", function(assert) {
+    assert.strictEqual(isAdminRequired(undefined), true);
+});
+
+QUnit.module("ADMIN_REQUIRED_TOOLTIP");
+
+QUnit.test("exposes the canonical cross-module tooltip text", function(assert) {
+    // Matches the AdminGatedButton convention documented in
+    // docs/solutions/best-practices/2026-05-28-cockpit-module-admin-gating-and-error-surfacing.md
+    assert.strictEqual(ADMIN_REQUIRED_TOOLTIP, "Administrative access required");
+});
+
+QUnit.start();

--- a/pkg/networkmanager/wifi-admin-gated-button.jsx
+++ b/pkg/networkmanager/wifi-admin-gated-button.jsx
@@ -21,7 +21,6 @@ import cockpit from "cockpit";
 import React from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
-import { ADMIN_REQUIRED_TOOLTIP } from "./wifi-admin-gating";
 
 const _ = cockpit.gettext;
 
@@ -52,5 +51,9 @@ export const AdminGatedButton = ({
     if (!isAdminGated)
         return button;
 
-    return <Tooltip content={_(ADMIN_REQUIRED_TOOLTIP)}>{button}</Tooltip>;
+    // Literal kept in sync with ADMIN_REQUIRED_TOOLTIP in wifi-admin-gating.js
+    // so xgettext sees the string for extraction. The test in
+    // test-wifi-admin-gating.js pins the constant; any drift between this
+    // literal and the constant should be caught in review.
+    return <Tooltip content={_("Administrative access required")}>{button}</Tooltip>;
 };

--- a/pkg/networkmanager/wifi-admin-gated-button.jsx
+++ b/pkg/networkmanager/wifi-admin-gated-button.jsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2026 Hat Labs
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
+import { ADMIN_REQUIRED_TOOLTIP } from "./wifi-admin-gating";
+
+const _ = cockpit.gettext;
+
+// Button wrapper used at every WiFi control site that triggers an
+// admin-required action. When gated, the underlying PatternFly Button is
+// rendered with `isAriaDisabled` (which suppresses onClick via
+// preventDefault) and wrapped in a Tooltip explaining why.
+//
+// Composes with the caller's own `isDisabled` / `isAriaDisabled` /
+// `isLoading` so transient disable states (e.g. an in-flight scan) still
+// work.
+export const AdminGatedButton = ({
+    isAdminGated,
+    isAriaDisabled,
+    isDisabled,
+    children,
+    ...rest
+}) => {
+    const button = (
+        <Button
+            {...rest}
+            isAriaDisabled={isAdminGated || isAriaDisabled || isDisabled}
+        >
+            {children}
+        </Button>
+    );
+
+    if (!isAdminGated)
+        return button;
+
+    return <Tooltip content={_(ADMIN_REQUIRED_TOOLTIP)}>{button}</Tooltip>;
+};

--- a/pkg/networkmanager/wifi-admin-gating.js
+++ b/pkg/networkmanager/wifi-admin-gating.js
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2026 Hat Labs
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Admin-gating primitives for the HaLOS-owned WiFi surface.
+ *
+ * Controls that ultimately invoke `superuser: "require"` spawns or Polkit-
+ * restricted DBus calls must be visibly disabled in Cockpit's Limited Access
+ * mode so the user does not click into a silent failure.
+ *
+ * Cross-module convention is documented in
+ * docs/solutions/best-practices/2026-05-28-cockpit-module-admin-gating-and-error-surfacing.md
+ * in the halos workspace; the pilot lives in cockpit-container-apps. UI
+ * primitives that depend on PatternFly live in
+ * `./wifi-admin-gated-button.jsx` so this module stays lightweight enough
+ * to be exercised by the QUnit suite.
+ */
+
+import cockpit from "cockpit";
+import { useEffect, useState } from "react";
+
+export const ADMIN_REQUIRED_TOOLTIP = "Administrative access required";
+
+// Treat the loading window (`allowed === null`) and a missing permission
+// handle as gated. The contract is tested in test-wifi-admin-gating.js.
+export function isAdminRequired(permission) {
+    if (!permission) return true;
+    return permission.allowed !== true;
+}
+
+// Subscribe to `cockpit.permission({ admin: true })` once per mount and
+// mirror `allowed` into React state so the UI re-renders on transitions.
+//
+// Outside a Cockpit page (e.g. unit-test harness without a cockpit global)
+// the hook resolves to `allowed: true` so it does not gate development.
+export function useAdminPermission() {
+    const [allowed, setAllowed] = useState(null);
+
+    useEffect(() => {
+        if (!cockpit || typeof cockpit.permission !== "function") {
+            setAllowed(true);
+            return undefined;
+        }
+
+        const permission = cockpit.permission({ admin: true });
+        const sync = () => setAllowed(permission.allowed);
+        sync();
+        permission.addEventListener("changed", sync);
+
+        return () => {
+            permission.removeEventListener("changed", sync);
+            if (typeof permission.close === "function")
+                permission.close();
+        };
+    }, []);
+
+    return { allowed };
+}

--- a/pkg/networkmanager/wifi-admin-gating.js
+++ b/pkg/networkmanager/wifi-admin-gating.js
@@ -35,40 +35,56 @@
 import cockpit from "cockpit";
 import { useEffect, useState } from "react";
 
+// Source-string anchor for translators. The actual `_("...")` call lives at
+// the call site in `wifi-admin-gated-button.jsx` so xgettext can extract it.
+// The QUnit suite pins this constant to keep cross-module copies aligned.
 export const ADMIN_REQUIRED_TOOLTIP = "Administrative access required";
 
-// Treat the loading window (`allowed === null`) and a missing permission
-// handle as gated. The contract is tested in test-wifi-admin-gating.js.
-export function isAdminRequired(permission) {
-    if (!permission) return true;
-    return permission.allowed !== true;
+// Treat the loading window (`allowed === null`) as gated alongside the
+// resolved-denied state. Cockpit's `Permission.allowed` is `null` until the
+// initial DBus check resolves; if we let null fall through, controls would
+// flicker enabled during page load. Contract pinned in test-wifi-admin-gating.js.
+export function isAdminRequired(allowed) {
+    return allowed !== true;
 }
 
-// Subscribe to `cockpit.permission({ admin: true })` once per mount and
-// mirror `allowed` into React state so the UI re-renders on transitions.
+// Pure subscription helper. Takes cockpit (so the QUnit suite can inject a
+// stub) and an onChange callback, and returns a cleanup function. Mirrors
+// the pattern used by upstream `pkg/lib/superuser.js:117-122`.
 //
-// Outside a Cockpit page (e.g. unit-test harness without a cockpit global)
-// the hook resolves to `allowed: true` so it does not gate development.
+// When cockpit is unavailable (test harness, dev environment without a
+// Cockpit session) the helper resolves to `allowed: true` so it does not
+// gate development.
+export function subscribeAdminPermission(cockpitObj, onChange) {
+    if (!cockpitObj || typeof cockpitObj.permission !== "function") {
+        onChange(true);
+        return () => {};
+    }
+
+    const permission = cockpitObj.permission({ admin: true });
+    const sync = () => onChange(permission.allowed);
+    sync();
+    permission.addEventListener("changed", sync);
+
+    return () => {
+        permission.removeEventListener("changed", sync);
+        if (typeof permission.close === "function")
+            permission.close();
+    };
+}
+
+// React hook wrapper around subscribeAdminPermission. The hook is a thin
+// shim; all behavioral logic lives in the pure helper above so it can be
+// exercised without a React render harness.
+//
+// Note: upstream `Permission.maybe_reload` (pkg/lib/cockpit.js) reloads the
+// whole page when admin status changes after initial resolution, so the
+// `changed` listener really only matters for the initial null → resolved
+// transition — subsequent transitions never reach React.
 export function useAdminPermission() {
     const [allowed, setAllowed] = useState(null);
 
-    useEffect(() => {
-        if (!cockpit || typeof cockpit.permission !== "function") {
-            setAllowed(true);
-            return undefined;
-        }
-
-        const permission = cockpit.permission({ admin: true });
-        const sync = () => setAllowed(permission.allowed);
-        sync();
-        permission.addEventListener("changed", sync);
-
-        return () => {
-            permission.removeEventListener("changed", sync);
-            if (typeof permission.close === "function")
-                permission.close();
-        };
-    }, []);
+    useEffect(() => subscribeAdminPermission(cockpit, setAllowed), []);
 
     return { allowed };
 }

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -1378,9 +1378,16 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                     : undefined}>
                     <CardTitle>{_("Access Point")}</CardTitle>
                 </CardHeader>
-                {!canEnableAP && (
+                {(!canEnableAP || (isAdminGated && canEnableAP)) && (
                     <CardBody>
-                        {_("This WiFi adapter does not support Access Point mode.")}
+                        {!canEnableAP && _("This WiFi adapter does not support Access Point mode.")}
+                        {isAdminGated && canEnableAP && (
+                            <Alert
+                                variant="info"
+                                isInline
+                                title={_("Administrative access required to enable the Access Point.")}
+                            />
+                        )}
                     </CardBody>
                 )}
             </Card>
@@ -1392,6 +1399,11 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
             <CardHeader actions={{
                 actions: (
                     <>
+                        {/* Configure is gated even though it only opens a dialog: every
+                            settings change inside WiFiAPDialog ultimately needs admin to
+                            persist, so allowing the dialog to open would lead the user
+                            into a workflow they can't complete. Matches the audit
+                            (halos-org/halos#121) prescription. */}
                         <AdminGatedButton variant="secondary" onClick={handleConfigure} style={{ marginRight: "var(--pf-global--spacer--sm)" }} isAdminGated={isAdminGated}>
                             {_("Configure")}
                         </AdminGatedButton>
@@ -1409,6 +1421,14 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                         variant="danger"
                         isInline
                         title={error}
+                        style={{ marginBottom: "1rem" }}
+                    />
+                )}
+                {isAdminGated && (
+                    <Alert
+                        variant="info"
+                        isInline
+                        title={_("Administrative access required to configure or disable the Access Point.")}
                         style={{ marginBottom: "1rem" }}
                     />
                 )}
@@ -1771,7 +1791,7 @@ export const WiFiPage = ({ iface, dev }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
     const { allowed: adminAllowed } = useAdminPermission();
-    const adminGated = isAdminRequired({ allowed: adminAllowed });
+    const adminGated = isAdminRequired(adminAllowed);
     const [scanning, setScanning] = useState(false);
     const [accessPoints, setAccessPoints] = useState([]);
     const [error, setError] = useState(null);

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -43,6 +43,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Name, NetworkModal, dialogSave } from "./dialogs-common";
 import { ModelContext } from './model-context';
 import { decode_nm_property } from './utils';
+import { isAdminRequired, useAdminPermission } from './wifi-admin-gating';
+import { AdminGatedButton } from './wifi-admin-gated-button';
 
 const _ = cockpit.gettext;
 
@@ -106,9 +108,12 @@ const SecurityBadge = ({ security }) => {
 };
 
 // WiFi Network List Item
-const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected }) => {
+const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected, isAdminGated }) => {
+    const style = isAdminGated
+        ? { cursor: 'not-allowed', opacity: 0.5 }
+        : { cursor: 'pointer' };
     return (
-        <ListItem onClick={onClick} style={{ cursor: 'pointer' }}>
+        <ListItem onClick={isAdminGated ? undefined : onClick} aria-disabled={isAdminGated || undefined} style={style}>
             <Flex alignItems={{ default: 'alignItemsCenter' }}>
                 <FlexItem flex={{ default: 'flex_1' }}>
                     <span style={{ fontWeight: isConnected ? 'bold' : 'normal' }}>
@@ -128,7 +133,7 @@ const WiFiNetworkItem = ({ ap, onClick, isSaved, isConnected }) => {
 };
 
 // WiFi Network List Component
-const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new Set(), connectedSSID }) => {
+const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new Set(), connectedSSID, isAdminGated }) => {
     if (accessPoints.length === 0 && !scanning) {
         return (
             <EmptyState>
@@ -171,6 +176,7 @@ const WiFiNetworkList = ({ accessPoints, onConnect, scanning, savedSSIDs = new S
                     onClick={() => onConnect(ap)}
                     isSaved={savedSSIDs.has(ap.ssid)}
                     isConnected={ap.ssid === connectedSSID}
+                    isAdminGated={isAdminGated}
                 />
             ))}
         </List>
@@ -1291,7 +1297,7 @@ const WiFiAPClientList = ({ iface }) => {
 };
 
 // WiFi AP Configuration Status Component
-export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canEnableAP, onEnableAP, deviceUnavailable }) => {
+export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canEnableAP, onEnableAP, deviceUnavailable, isAdminGated }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
     const [error, setError] = useState(null);
@@ -1359,13 +1365,14 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                 <CardHeader actions={canEnableAP
                     ? {
                         actions: (
-                            <Button
+                            <AdminGatedButton
                                 variant="primary"
                                 onClick={onEnableAP}
                                 isDisabled={deviceUnavailable}
+                                isAdminGated={isAdminGated}
                             >
                                 {_("Enable")}
-                            </Button>
+                            </AdminGatedButton>
                         )
                     }
                     : undefined}>
@@ -1385,12 +1392,12 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
             <CardHeader actions={{
                 actions: (
                     <>
-                        <Button variant="secondary" onClick={handleConfigure} style={{ marginRight: "var(--pf-global--spacer--sm)" }}>
+                        <AdminGatedButton variant="secondary" onClick={handleConfigure} style={{ marginRight: "var(--pf-global--spacer--sm)" }} isAdminGated={isAdminGated}>
                             {_("Configure")}
-                        </Button>
-                        <Button variant="danger" onClick={handleDisable}>
+                        </AdminGatedButton>
+                        <AdminGatedButton variant="danger" onClick={handleDisable} isAdminGated={isAdminGated}>
                             {_("Disable")}
-                        </Button>
+                        </AdminGatedButton>
                     </>
                 )
             }}>
@@ -1763,6 +1770,8 @@ function getWiFiConnectionStates(dev, model) {
 export const WiFiPage = ({ iface, dev }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
+    const { allowed: adminAllowed } = useAdminPermission();
+    const adminGated = isAdminRequired({ allowed: adminAllowed });
     const [scanning, setScanning] = useState(false);
     const [accessPoints, setAccessPoints] = useState([]);
     const [error, setError] = useState(null);
@@ -2216,15 +2225,16 @@ export const WiFiPage = ({ iface, dev }) => {
     // Action links for WiFi unavailable alert (only show enable button if rfkill blocked)
     const wifiUnavailableActionLinks = rfkillBlocked
         ? (
-            <Button
+            <AdminGatedButton
                 variant="link"
                 isInline
                 onClick={handleEnableWifi}
                 isLoading={enablingWifi}
                 isDisabled={enablingWifi}
+                isAdminGated={adminGated}
             >
                 {enablingWifi ? _("Enabling...") : _("Enable WiFi")}
-            </Button>
+            </AdminGatedButton>
         )
         : undefined;
 
@@ -2267,6 +2277,7 @@ export const WiFiPage = ({ iface, dev }) => {
                     canEnableAP={canEnableAP}
                     onEnableAP={handleEnableAP}
                     deviceUnavailable={deviceUnavailable}
+                    isAdminGated={adminGated}
                 />
             </div>
 
@@ -2281,14 +2292,14 @@ export const WiFiPage = ({ iface, dev }) => {
                     <CardTitle>{_("WiFi Networks")}</CardTitle>
                     <Flex style={{ gap: "1rem" }}>
                         <FlexItem>
-                            <Button onClick={handleScan} isDisabled={scanning || deviceUnavailable} style={{ minWidth: "7rem" }}>
+                            <AdminGatedButton onClick={handleScan} isDisabled={scanning || deviceUnavailable} style={{ minWidth: "7rem" }} isAdminGated={adminGated}>
                                 {scanning ? _("Scanning...") : _("Scan")}
-                            </Button>
+                            </AdminGatedButton>
                         </FlexItem>
                         <FlexItem>
-                            <Button variant="secondary" onClick={handleConnectHidden} isDisabled={deviceUnavailable}>
+                            <AdminGatedButton variant="secondary" onClick={handleConnectHidden} isDisabled={deviceUnavailable} isAdminGated={adminGated}>
                                 {_("Connect to Hidden Network")}
-                            </Button>
+                            </AdminGatedButton>
                         </FlexItem>
                     </Flex>
                 </CardHeader>
@@ -2309,12 +2320,21 @@ export const WiFiPage = ({ iface, dev }) => {
                             style={{ marginBottom: "1rem" }}
                         />
                     )}
+                    {adminGated && (
+                        <Alert
+                            variant="info"
+                            isInline
+                            title={_("Administrative access required to scan or connect to networks.")}
+                            style={{ marginBottom: "1rem" }}
+                        />
+                    )}
                     <WiFiNetworkList
                         accessPoints={accessPoints}
                         onConnect={handleConnect}
                         scanning={scanning}
                         savedSSIDs={savedSSIDs}
                         connectedSSID={connectedSSID}
+                        isAdminGated={adminGated}
                     />
                 </CardBody>
             </Card>


### PR DESCRIPTION
## Why

In Cockpit's Limited Access mode the HaLOS WiFi surface ships six `superuser: "require"` spawn callsites plus a `superuser: "require"` DBus/file path with no UI feedback when Polkit rejects them. The user clicks Enable / Configure / Disable AP, Enable WiFi, Scan, Connect to Hidden Network, or a per-network entry and the action fails silently.

This change matches the cross-module admin-gating pattern adopted by the rest of HaLOS' Cockpit modules — see the audit at halos-org/halos#121 and the pilot at halos-org/cockpit-container-apps#80.

## What

* `pkg/networkmanager/wifi-admin-gating.js` — pure `isAdminRequired` predicate (treats `allowed === null` and missing handle as gated, per pilot decision) and a `useAdminPermission` React hook subscribing to `cockpit.permission({ admin: true })`. No PatternFly imports so the QUnit suite can exercise it directly.
* `pkg/networkmanager/wifi-admin-gated-button.jsx` — PatternFly button wrapper. When gated, renders `isAriaDisabled` (suppresses onClick via preventDefault) inside a Tooltip explaining \"Administrative access required\". Composes with the caller's existing `isDisabled` / `isAriaDisabled` / `isLoading` so transient disable states (e.g. an in-flight scan) still work.
* `pkg/networkmanager/wifi.jsx` — `WiFiPage` subscribes once and threads `adminGated` into `WiFiAPConfig` (Enable / Configure / Disable buttons), `WiFiNetworkList` (per-row gating), and the Scan / Connect-Hidden / Enable-WiFi top-level buttons. `WiFiNetworkList` rows render `aria-disabled` with reduced opacity and no `onClick` when gated; a single inline Alert above the list explains why instead of a per-row tooltip.
* `pkg/networkmanager/test-wifi-admin-gating.js` + `files.js` — QUnit tests for the gating contract.

## Scope (per audit)

Only the HaLOS-owned WiFi surface is touched. Upstream files (`firewall.jsx`, `firewall-switch.jsx`, `firewall-client.js`, `network-interface.jsx`, `interfaces.js`, `dialogs-common.jsx`, `wireguard.jsx`) are unmodified — they already have working `readonly` / `show_unexpected_error` paths and rebasing the fork is cheaper if we leave them alone.

## Note on the audit's \"handleDisable swallow\"

The audit (halos-org/halos#121) called out `WiFiAPConfig.handleDisable` as setting an error on an unmounted component. Tracing the current code: `setError` lands on `WiFiAPConfig` (which stays mounted), not on the closing `DisableAPConfirmDialog`. The Alert at `wifi.jsx:1400-1407` does render the error correctly. The \"swallow\" described in the audit doesn't reproduce in this branch, so no change is needed there. Calling it out so the audit's verdict can be reconciled.

## Verification

Behavioral verification of rendered buttons happens on hardware in Limited Access mode — see the checklist in halos-org/cockpit-networkmanager-halos#13. Local steps already passed:

* \`npm run eslint\` clean on all changed files
* \`node build.js networkmanager\` builds the QUnit bundle for the new test (\`qunit/networkmanager/test-wifi-admin-gating.{js,css,html}\`) successfully
* Per-prop contract pinned by the new QUnit tests:
  * \`isAdminRequired({ allowed: null })\` → \`true\`
  * \`isAdminRequired({ allowed: false })\` → \`true\`
  * \`isAdminRequired({ allowed: true })\` → \`false\`
  * \`isAdminRequired(null)\` / \`isAdminRequired(undefined)\` → \`true\`
  * \`ADMIN_REQUIRED_TOOLTIP === \"Administrative access required\"\`

Refs halos-org/cockpit-networkmanager-halos#13
Refs halos-org/halos#121

🤖 Generated with [Claude Code](https://claude.com/claude-code)