### PR TITLE
networkmanager: don't admin-gate WiFi Scan

### DIFF
--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -2312,9 +2312,14 @@ export const WiFiPage = ({ iface, dev }) => {
                     <CardTitle>{_("WiFi Networks")}</CardTitle>
                     <Flex style={{ gap: "1rem" }}>
                         <FlexItem>
-                            <AdminGatedButton onClick={handleScan} isDisabled={scanning || deviceUnavailable} style={{ minWidth: "7rem" }} isAdminGated={adminGated}>
+                            {/* Scan is intentionally NOT admin-gated. NetworkManager's polkit
+                                action `org.freedesktop.NetworkManager.wifi.scan` defaults to
+                                `yes` for any active session, so RequestScan succeeds in
+                                Limited Access. Gating it would make a working control look
+                                broken. */}
+                            <Button onClick={handleScan} isDisabled={scanning || deviceUnavailable} style={{ minWidth: "7rem" }}>
                                 {scanning ? _("Scanning...") : _("Scan")}
-                            </AdminGatedButton>
+                            </Button>
                         </FlexItem>
                         <FlexItem>
                             <AdminGatedButton variant="secondary" onClick={handleConnectHidden} isDisabled={deviceUnavailable} isAdminGated={adminGated}>
@@ -2344,7 +2349,7 @@ export const WiFiPage = ({ iface, dev }) => {
                         <Alert
                             variant="info"
                             isInline
-                            title={_("Administrative access required to scan or connect to networks.")}
+                            title={_("Administrative access required to connect to networks.")}
                             style={{ marginBottom: "1rem" }}
                         />
                     )}


### PR DESCRIPTION
Follow-up to #74.

PR #74 gated the Scan button along with the other six WiFi controls under the audit's (halos-org/halos#121) blanket "admin-required UI action" prescription. While verifying the deployed package: does scanning actually need admin?

It doesn't, and the strongest evidence is internal to this very module: `WiFiPage` already calls `handleScan()` automatically on mount (`wifi.jsx:2215-2222`) and every 15 seconds (`wifi.jsx:2224-2236`) without any admin check. If `wifi.scan` actually needed elevation, those background calls would fail continuously in Limited Access and the network list would never populate. The fact that auto-scan works (confirmed in production) means `RequestScan` succeeds without admin — which matches NetworkManager's polkit default: `org.freedesktop.NetworkManager.wifi.scan` is `yes` for any active session on Debian.

Gating the manual button while leaving the background timer ungated was internally inconsistent. It also makes a working control look broken — exactly the failure mode this audit was trying to fix in the *other* direction.

## What changes

- Revert Scan from `AdminGatedButton` back to plain `Button` with a code comment explaining the polkit reasoning so this isn't re-gated by a future audit pass.
- Update the inline Alert text from "Administrative access required to scan or connect to networks" to "Administrative access required to connect to networks."

## What stays gated

- AP Enable / Configure / Disable — submit paths spawn with `superuser: "require"`.
- Enable WiFi (rfkill unblock) — `superuser: "require"`.
- Connect / Connect to Hidden Network — new-network setup (`AddAndActivateConnection`) needs the `settings.modify.system` polkit action, which does require admin. (Saved-network reconnects via `ActivateConnection` *may* succeed for active sessions per `network-control` defaults, but the typical case — joining a new network — needs admin and the row-level gate handles both.)

Refs halos-org/cockpit-networkmanager-halos#13