### PR TITLE
feat(networkmanager): AP dialog mode selector + Bridged fields (Unit 5)

### DIFF
--- a/pkg/networkmanager/ap-integration-mode.js
+++ b/pkg/networkmanager/ap-integration-mode.js
@@ -113,3 +113,66 @@ export function classifyApIntegrationMode(apConnection) {
 export function isManagedApMode(mode) {
     return mode === AP_INTEGRATION_MODES.ISOLATED || mode === AP_INTEGRATION_MODES.BRIDGED;
 }
+
+// Selectable AP channels per band. DFS-free 5 GHz only — the minimal firmware
+// drops DFS/ACS, so Bridged needs a fixed, non-DFS channel (R3).
+export const AP_CHANNELS_24 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+export const AP_CHANNELS_5_DFS_FREE = [36, 40, 44, 48, 149, 153, 157, 161, 165];
+
+function channelsForBand(band) {
+    return band === "a" ? AP_CHANNELS_5_DFS_FREE : AP_CHANNELS_24;
+}
+
+// Fixed-channel default per band when Bridged needs a concrete channel: 2.4 GHz
+// ch 6 (the conventional non-overlapping pick), 5 GHz ch 36 (lowest DFS-free).
+function defaultChannelForBand(band) {
+    return band === "a" ? 36 : 6;
+}
+
+/**
+ * The ipv4 settings an AP carries in the given mode. Isolated runs a local
+ * DHCP/NAT island (R2); Bridged (and anything else) carries none — the bridge
+ * owns addressing, so the dialog must never emit the 10.42.0.x range (R6/R7).
+ *
+ * @param {'isolated'|'bridged'|'custom'} mode
+ * @param {string} ipAddress
+ * @param {number|string} prefix
+ * @returns {{method: string, address_data: object[]}|null}
+ */
+export function apModeIpv4Settings(mode, ipAddress, prefix) {
+    if (mode === AP_INTEGRATION_MODES.ISOLATED)
+        return { method: "shared", address_data: [{ address: ipAddress, prefix: String(prefix) }] };
+    return null;
+}
+
+/**
+ * Coerce a channel selection to one valid for the mode and band. Isolated keeps
+ * the selection (including Automatic, 0). Bridged requires a fixed channel (R3),
+ * so Automatic or a channel not in the band falls to that band's default
+ * (2.4 GHz ch 6, 5 GHz ch 36).
+ *
+ * @param {'isolated'|'bridged'|'custom'} mode
+ * @param {string} band - "bg" (2.4 GHz) or "a" (5 GHz)
+ * @param {number} channel
+ * @returns {number}
+ */
+export function apModeNormalizeChannel(mode, band, channel) {
+    if (mode !== AP_INTEGRATION_MODES.BRIDGED)
+        return channel;
+    const channels = channelsForBand(band);
+    return channels.includes(channel) ? channel : defaultChannelForBand(band);
+}
+
+/**
+ * Whether a channel selection is submittable in the given mode. Bridged forbids
+ * Automatic (0); Isolated allows it (R3).
+ *
+ * @param {'isolated'|'bridged'|'custom'} mode
+ * @param {number} channel
+ * @returns {boolean}
+ */
+export function isApModeChannelValid(mode, channel) {
+    if (mode === AP_INTEGRATION_MODES.BRIDGED)
+        return channel !== 0;
+    return true;
+}

--- a/pkg/networkmanager/ap-integration-mode.js
+++ b/pkg/networkmanager/ap-integration-mode.js
@@ -176,3 +176,19 @@ export function isApModeChannelValid(mode, channel) {
         return channel !== 0;
     return true;
 }
+
+/**
+ * The channel value to write into the saved connection, or null to omit it.
+ * Bridged always emits a concrete fixed channel (R3) — never Automatic — so the
+ * "fixed channel" invariant holds regardless of submit-time state. Isolated
+ * omits the channel when Automatic (0), letting NM pick.
+ *
+ * @param {'isolated'|'bridged'|'custom'} mode
+ * @param {string} band
+ * @param {number} channel
+ * @returns {number|null}
+ */
+export function apModeChannelToEmit(mode, band, channel) {
+    const normalized = apModeNormalizeChannel(mode, band, channel);
+    return normalized !== 0 ? normalized : null;
+}

--- a/pkg/networkmanager/test-wifi-hooks.js
+++ b/pkg/networkmanager/test-wifi-hooks.js
@@ -28,7 +28,7 @@ import QUnit from "qunit-tests";
 import { parseSecurityFlags, ConnectionState, apIntegrationModeLabel, apIpRangeText } from "./wifi-hooks";
 import {
     classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES,
-    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid,
+    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid, apModeChannelToEmit,
 } from "./ap-integration-mode";
 
 // ============================================================================
@@ -759,6 +759,12 @@ QUnit.test("Custom/unknown emits no ipv4", function(assert) {
     assert.strictEqual(apModeIpv4Settings(undefined, "10.42.0.1", 24), null);
 });
 
+QUnit.test("Isolated accepts a string prefix unchanged", function(assert) {
+    assert.deepEqual(
+        apModeIpv4Settings(AP_INTEGRATION_MODES.ISOLATED, "10.42.0.1", "24"),
+        { method: "shared", address_data: [{ address: "10.42.0.1", prefix: "24" }] });
+});
+
 // ============================================================================
 // Tests for apModeNormalizeChannel (R3 fixed channel in Bridged)
 // ============================================================================
@@ -788,6 +794,10 @@ QUnit.test("Bridged resets a channel invalid for the band to that band's default
     assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "bg", 36), 6);
 });
 
+QUnit.test("Bridged treats an unknown band as 2.4 GHz (defaults to ch 6)", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, undefined, 0), 6);
+});
+
 // ============================================================================
 // Tests for isApModeChannelValid (submit gate, R3)
 // ============================================================================
@@ -801,6 +811,28 @@ QUnit.test("Bridged rejects Automatic (0), accepts a fixed channel", function(as
 
 QUnit.test("Isolated accepts Automatic (0)", function(assert) {
     assert.strictEqual(isApModeChannelValid(AP_INTEGRATION_MODES.ISOLATED, 0), true);
+});
+
+QUnit.test("Custom/unknown mode accepts Automatic (only Bridged is constrained)", function(assert) {
+    assert.strictEqual(isApModeChannelValid(AP_INTEGRATION_MODES.CUSTOM, 0), true);
+    assert.strictEqual(isApModeChannelValid(undefined, 0), true);
+});
+
+// ============================================================================
+// Tests for apModeChannelToEmit (what the saved connection carries, R3)
+// ============================================================================
+
+QUnit.module("apModeChannelToEmit");
+
+QUnit.test("Isolated omits the channel when Automatic, keeps a fixed pick", function(assert) {
+    assert.strictEqual(apModeChannelToEmit(AP_INTEGRATION_MODES.ISOLATED, "bg", 0), null);
+    assert.strictEqual(apModeChannelToEmit(AP_INTEGRATION_MODES.ISOLATED, "bg", 11), 11);
+});
+
+QUnit.test("Bridged always emits a concrete channel, never null — even from Automatic", function(assert) {
+    assert.strictEqual(apModeChannelToEmit(AP_INTEGRATION_MODES.BRIDGED, "bg", 0), 6);
+    assert.strictEqual(apModeChannelToEmit(AP_INTEGRATION_MODES.BRIDGED, "a", 0), 36);
+    assert.strictEqual(apModeChannelToEmit(AP_INTEGRATION_MODES.BRIDGED, "bg", 11), 11);
 });
 
 // ============================================================================

--- a/pkg/networkmanager/test-wifi-hooks.js
+++ b/pkg/networkmanager/test-wifi-hooks.js
@@ -26,7 +26,10 @@
 
 import QUnit from "qunit-tests";
 import { parseSecurityFlags, ConnectionState, apIntegrationModeLabel, apIpRangeText } from "./wifi-hooks";
-import { classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES } from "./ap-integration-mode";
+import {
+    classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES,
+    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid,
+} from "./ap-integration-mode";
 
 // ============================================================================
 // Tests for parseSecurityFlags
@@ -733,6 +736,71 @@ QUnit.test("Unknown mode degrades to the no-10.42 Custom text", function(assert)
     const text = apIpRangeText(undefined, undefined);
     assert.strictEqual(text, "Externally configured");
     assert.strictEqual(text.includes("10.42"), false);
+});
+
+// ============================================================================
+// Tests for apModeIpv4Settings (dialog mode-aware ipv4 emission, R6/R7)
+// ============================================================================
+
+QUnit.module("apModeIpv4Settings");
+
+QUnit.test("Isolated emits shared method + address (prefix coerced to string)", function(assert) {
+    assert.deepEqual(
+        apModeIpv4Settings(AP_INTEGRATION_MODES.ISOLATED, "10.42.0.1", 24),
+        { method: "shared", address_data: [{ address: "10.42.0.1", prefix: "24" }] });
+});
+
+QUnit.test("Bridged emits no ipv4 (the bridge owns addressing)", function(assert) {
+    assert.strictEqual(apModeIpv4Settings(AP_INTEGRATION_MODES.BRIDGED, "10.42.0.1", 24), null);
+});
+
+QUnit.test("Custom/unknown emits no ipv4", function(assert) {
+    assert.strictEqual(apModeIpv4Settings(AP_INTEGRATION_MODES.CUSTOM, "10.42.0.1", 24), null);
+    assert.strictEqual(apModeIpv4Settings(undefined, "10.42.0.1", 24), null);
+});
+
+// ============================================================================
+// Tests for apModeNormalizeChannel (R3 fixed channel in Bridged)
+// ============================================================================
+
+QUnit.module("apModeNormalizeChannel");
+
+QUnit.test("Isolated keeps Automatic (0) and any selection", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.ISOLATED, "bg", 0), 0);
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.ISOLATED, "bg", 11), 11);
+});
+
+QUnit.test("Bridged 2.4 GHz with Automatic defaults to channel 6", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "bg", 0), 6);
+});
+
+QUnit.test("Bridged 5 GHz with Automatic defaults to channel 36", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "a", 0), 36);
+});
+
+QUnit.test("Bridged keeps a channel valid for the band", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "bg", 11), 11);
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "a", 149), 149);
+});
+
+QUnit.test("Bridged resets a channel invalid for the band to that band's default", function(assert) {
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "a", 6), 36);
+    assert.strictEqual(apModeNormalizeChannel(AP_INTEGRATION_MODES.BRIDGED, "bg", 36), 6);
+});
+
+// ============================================================================
+// Tests for isApModeChannelValid (submit gate, R3)
+// ============================================================================
+
+QUnit.module("isApModeChannelValid");
+
+QUnit.test("Bridged rejects Automatic (0), accepts a fixed channel", function(assert) {
+    assert.strictEqual(isApModeChannelValid(AP_INTEGRATION_MODES.BRIDGED, 0), false);
+    assert.strictEqual(isApModeChannelValid(AP_INTEGRATION_MODES.BRIDGED, 6), true);
+});
+
+QUnit.test("Isolated accepts Automatic (0)", function(assert) {
+    assert.strictEqual(isApModeChannelValid(AP_INTEGRATION_MODES.ISOLATED, 0), true);
 });
 
 // ============================================================================

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -48,7 +48,7 @@ import { AdminGatedButton } from './wifi-admin-gated-button';
 import { apIntegrationModeLabel, apIpRangeText } from './wifi-hooks';
 import {
     classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES,
-    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid,
+    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid, apModeChannelToEmit,
     AP_CHANNELS_24, AP_CHANNELS_5_DFS_FREE,
 } from './ap-integration-mode';
 
@@ -364,17 +364,6 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
 
     // Safely access settings with fallbacks
     const safeSettings = settings || {};
-    const [iface, setIface] = useState(safeSettings.connection?.interface_name || (dev && dev.Interface) || "");
-    const [ssid, setSSID] = useState(safeSettings.wifi?.ssid || generateDefaultSSID(dev));
-    const [password, setPassword] = useState("");
-    const [securityType, setSecurityType] = useState(safeSettings.wifi_security?.key_mgmt || "wpa-psk");
-    const [band, setBand] = useState(safeSettings.wifi?.band || "bg");
-    const [channel, setChannel] = useState(safeSettings.wifi?.channel || 0);
-    const [hidden, setHidden] = useState(safeSettings.wifi?.hidden || false);
-    const [ipAddress, setIPAddress] = useState(safeSettings.ipv4?.address_data?.[0]?.address || "10.42.0.1");
-    const [prefix, setPrefix] = useState(safeSettings.ipv4?.address_data?.[0]?.prefix || 24);
-    const [dialogError, setDialogError] = useState("");
-
     const isCreateDialog = !connection;
 
     // The AP's current integration mode (Isolated on create). Custom APs never
@@ -383,8 +372,22 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
     const currentMode = isCreateDialog
         ? AP_INTEGRATION_MODES.ISOLATED
         : classifyApIntegrationMode(connection);
-    const [mode, setMode] = useState(
-        isManagedApMode(currentMode) ? currentMode : AP_INTEGRATION_MODES.ISOLATED);
+    const initialMode = isManagedApMode(currentMode) ? currentMode : AP_INTEGRATION_MODES.ISOLATED;
+    const initialBand = safeSettings.wifi?.band || "bg";
+
+    const [iface, setIface] = useState(safeSettings.connection?.interface_name || (dev && dev.Interface) || "");
+    const [ssid, setSSID] = useState(safeSettings.wifi?.ssid || generateDefaultSSID(dev));
+    const [password, setPassword] = useState("");
+    const [securityType, setSecurityType] = useState(safeSettings.wifi_security?.key_mgmt || "wpa-psk");
+    const [band, setBand] = useState(initialBand);
+    // Normalize at mount so a Bridged AP never seeds the now-absent Automatic
+    // option (R3): an unset/Automatic channel becomes the band default.
+    const [channel, setChannel] = useState(apModeNormalizeChannel(initialMode, initialBand, safeSettings.wifi?.channel || 0));
+    const [hidden, setHidden] = useState(safeSettings.wifi?.hidden || false);
+    const [ipAddress, setIPAddress] = useState(safeSettings.ipv4?.address_data?.[0]?.address || "10.42.0.1");
+    const [prefix, setPrefix] = useState(safeSettings.ipv4?.address_data?.[0]?.prefix || 24);
+    const [dialogError, setDialogError] = useState("");
+    const [mode, setMode] = useState(initialMode);
     const isBridged = mode === AP_INTEGRATION_MODES.BRIDGED;
 
     // Validate SSID
@@ -508,6 +511,10 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
             }
         }
 
+        // Bridged always carries a fixed channel (R3), Isolated omits it when
+        // Automatic — one decision shared by every save branch below.
+        const emitChannel = apModeChannelToEmit(mode, band, channel);
+
         // Build Access Point connection settings
         const apSettings = {
             ...settings,
@@ -523,7 +530,7 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                 ssid,
                 mode: "ap",
                 band,
-                ...(channel !== 0 && { channel }), // Only include if not auto
+                ...(emitChannel !== null && { channel: emitChannel }),
                 ...(hidden && { hidden: true }), // Only include if hidden
             },
         };
@@ -588,8 +595,8 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                         args.push("ipv4.addresses", `${ipAddress}/${prefix}`);
                     }
 
-                    if (channel !== 0) {
-                        args.push("wifi.channel", String(channel));
+                    if (emitChannel !== null) {
+                        args.push("wifi.channel", String(emitChannel));
                     }
 
                     if (securityType !== "none" && password) {
@@ -769,9 +776,13 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                     <Alert
                         variant="warning"
                         isInline
-                        title={_("Applying this change may briefly disconnect AP clients, and this device's address may change. Afterward, reach it by its hostname.")}
+                        title={_("Switching network mode is disruptive")}
                         style={{ marginBottom: "1rem" }}
-                    />
+                    >
+                        <p>
+                            {_("Applying this change may briefly disconnect AP clients, and this device's address may change. Afterward, reach it by its hostname.")}
+                        </p>
+                    </Alert>
                 )}
 
                 <FormGroup label={_("Frequency Band")} fieldId={idPrefix + "-band-select"}>
@@ -843,9 +854,9 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
 
                 {isBridged
                     ? (
-                        <FormGroup label={_("IP addressing")} fieldId={idPrefix + "-bridged-ip-note"}>
+                        <FormGroup label={_("IP addressing")}>
                             <HelperText>
-                                <HelperTextItem id={idPrefix + "-bridged-ip-note"}>
+                                <HelperTextItem>
                                     {_("Clients receive addresses from your upstream gateway. This device has no separate AP subnet in Bridged mode.")}
                                 </HelperTextItem>
                             </HelperText>

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -46,7 +46,11 @@ import { decode_nm_property } from './utils';
 import { isAdminRequired, useAdminPermission } from './wifi-admin-gating';
 import { AdminGatedButton } from './wifi-admin-gated-button';
 import { apIntegrationModeLabel, apIpRangeText } from './wifi-hooks';
-import { classifyApIntegrationMode, isManagedApMode } from './ap-integration-mode';
+import {
+    classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES,
+    apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid,
+    AP_CHANNELS_24, AP_CHANNELS_5_DFS_FREE,
+} from './ap-integration-mode';
 
 const _ = cockpit.gettext;
 
@@ -373,6 +377,16 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
 
     const isCreateDialog = !connection;
 
+    // The AP's current integration mode (Isolated on create). Custom APs never
+    // reach this dialog (Configure is suppressed), so the selector offers only
+    // the two managed modes; a non-managed seed falls back to Isolated.
+    const currentMode = isCreateDialog
+        ? AP_INTEGRATION_MODES.ISOLATED
+        : classifyApIntegrationMode(connection);
+    const [mode, setMode] = useState(
+        isManagedApMode(currentMode) ? currentMode : AP_INTEGRATION_MODES.ISOLATED);
+    const isBridged = mode === AP_INTEGRATION_MODES.BRIDGED;
+
     // Validate SSID
     const validateSSID = (value) => {
         const str = typeof value === 'string' ? value : String(value || '');
@@ -435,7 +449,9 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
     const ssidValidation = validateSSID(ssid);
     const passwordValidation = validatePassword(password, securityType);
     const ipValidation = validateIP(ipAddress);
-    const isFormValid = ssidValidation.valid && passwordValidation.valid && ipValidation.valid;
+    const channelValid = isApModeChannelValid(mode, channel);
+    const isFormValid = ssidValidation.valid && passwordValidation.valid &&
+        (isBridged || ipValidation.valid) && channelValid;
 
     // Helper to create virtual interface for dual mode
     const createVirtualInterface = async (mainIface, apIface) => {
@@ -474,7 +490,9 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
 
         // Validate all fields
         if (!isFormValid) {
-            setDialogError(ssidValidation.message || passwordValidation.message || ipValidation.message);
+            const channelMessage = !channelValid ? _("Select a fixed channel for Bridged mode") : "";
+            setDialogError(ssidValidation.message || passwordValidation.message ||
+                (isBridged ? "" : ipValidation.message) || channelMessage);
             return;
         }
 
@@ -508,14 +526,19 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                 ...(channel !== 0 && { channel }), // Only include if not auto
                 ...(hidden && { hidden: true }), // Only include if hidden
             },
-            ipv4: {
-                method: "shared", // Enables DHCP server
-                address_data: [{ address: ipAddress, prefix: String(prefix) }],
-            },
-            ipv6: {
-                method: "ignore",
-            },
         };
+
+        // Isolated runs a local DHCP/NAT island; Bridged carries no ipv4/ipv6 —
+        // the bridge (wired up in Unit 6) owns addressing, so never emit the
+        // 10.42.0.x range here (R6/R7).
+        const ipv4 = apModeIpv4Settings(mode, ipAddress, prefix);
+        if (ipv4) {
+            apSettings.ipv4 = ipv4;
+            apSettings.ipv6 = { method: "ignore" };
+        } else {
+            delete apSettings.ipv4;
+            delete apSettings.ipv6;
+        }
 
         // Add security if not open network
         if (securityType !== "none") {
@@ -555,10 +578,15 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                         "autoconnect", "yes",
                         "ssid", ssid,
                         "mode", "ap",
-                        "ipv4.method", "shared",
-                        "ipv4.addresses", `${ipAddress}/${prefix}`,
                         "wifi.band", band,
                     ];
+
+                    // Isolated only — Bridged carries no ipv4 (R6/R7); the
+                    // enslave onto br0 is Unit 6.
+                    if (!isBridged) {
+                        args.push("ipv4.method", "shared");
+                        args.push("ipv4.addresses", `${ipAddress}/${prefix}`);
+                    }
 
                     if (channel !== 0) {
                         args.push("wifi.channel", String(channel));
@@ -712,12 +740,50 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                     </Alert>
                 )}
 
+                <FormGroup label={_("Network mode")} fieldId={idPrefix + "-mode-select"}>
+                    <select
+                        id={idPrefix + "-mode-select"}
+                        className="pf-v6-c-form-control"
+                        value={mode}
+                        onChange={(e) => {
+                            const newMode = e.target.value;
+                            setMode(newMode);
+                            setChannel(apModeNormalizeChannel(newMode, band, channel));
+                        }}
+                    >
+                        <option value={AP_INTEGRATION_MODES.ISOLATED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.ISOLATED)}</option>
+                        <option value={AP_INTEGRATION_MODES.BRIDGED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.BRIDGED)}</option>
+                    </select>
+                    <FormHelperText>
+                        <HelperText>
+                            <HelperTextItem>
+                                {isBridged
+                                    ? _("The AP joins your LAN through the wired connection.")
+                                    : _("The AP runs its own isolated network with local DHCP.")}
+                            </HelperTextItem>
+                        </HelperText>
+                    </FormHelperText>
+                </FormGroup>
+
+                {mode !== currentMode && (
+                    <Alert
+                        variant="warning"
+                        isInline
+                        title={_("Applying this change may briefly disconnect AP clients, and this device's address may change. Afterward, reach it by its hostname.")}
+                        style={{ marginBottom: "1rem" }}
+                    />
+                )}
+
                 <FormGroup label={_("Frequency Band")} fieldId={idPrefix + "-band-select"}>
                     <select
                         id={idPrefix + "-band-select"}
                         className="pf-v6-c-form-control"
                         value={band}
-                        onChange={(e) => setBand(e.target.value)}
+                        onChange={(e) => {
+                            const newBand = e.target.value;
+                            setBand(newBand);
+                            setChannel(apModeNormalizeChannel(mode, newBand, channel));
+                        }}
                     >
                         <option value="bg">{_("2.4 GHz")}</option>
                         <option value="a">{_("5 GHz")}</option>
@@ -738,18 +804,22 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                         value={channel}
                         onChange={(e) => setChannel(parseInt(e.target.value))}
                     >
-                        <option value="0">{_("Automatic")}</option>
-                        {band === "bg" && [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(ch => (
+                        {/* Bridged requires a fixed channel (minimal firmware drops ACS), so
+                            Automatic is offered in Isolated only (R3). */}
+                        {!isBridged && <option value="0">{_("Automatic")}</option>}
+                        {band === "bg" && AP_CHANNELS_24.map(ch => (
                             <option key={ch} value={ch}>{ch}</option>
                         ))}
-                        {band === "a" && [36, 40, 44, 48, 149, 153, 157, 161, 165].map(ch => (
+                        {band === "a" && AP_CHANNELS_5_DFS_FREE.map(ch => (
                             <option key={ch} value={ch}>{ch}</option>
                         ))}
                     </select>
                     <FormHelperText>
                         <HelperText>
                             <HelperTextItem>
-                                {_("Leave as Automatic unless experiencing interference")}
+                                {isBridged
+                                    ? _("Bridged mode needs a fixed channel.")
+                                    : _("Leave as Automatic unless experiencing interference")}
                             </HelperTextItem>
                         </HelperText>
                     </FormHelperText>
@@ -771,50 +841,64 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                     </FormHelperText>
                 </FormGroup>
 
-                <FormGroup label={_("IP Address")} fieldId={idPrefix + "-ip-input"}>
-                    <TextInput
-                        id={idPrefix + "-ip-input"}
-                        value={ipAddress}
-                        onChange={(_, val) => setIPAddress(val)}
-                        validated={ipAddress && !ipValidation.valid ? "error" : "default"}
-                    />
-                    {ipAddress && !ipValidation.valid && (
-                        <FormHelperText>
+                {isBridged
+                    ? (
+                        <FormGroup label={_("IP addressing")} fieldId={idPrefix + "-bridged-ip-note"}>
                             <HelperText>
-                                <HelperTextItem variant="error">
-                                    {ipValidation.message}
+                                <HelperTextItem id={idPrefix + "-bridged-ip-note"}>
+                                    {_("Clients receive addresses from your upstream gateway. This device has no separate AP subnet in Bridged mode.")}
                                 </HelperTextItem>
                             </HelperText>
-                        </FormHelperText>
-                    )}
-                    {(!ipAddress || ipValidation.valid) && (
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>
-                                    {_("Default: 10.42.0.1")}
-                                </HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
-                    )}
-                </FormGroup>
+                        </FormGroup>
+                    )
+                    : (
+                        <>
+                            <FormGroup label={_("IP Address")} fieldId={idPrefix + "-ip-input"}>
+                                <TextInput
+                                id={idPrefix + "-ip-input"}
+                                value={ipAddress}
+                                onChange={(_, val) => setIPAddress(val)}
+                                validated={ipAddress && !ipValidation.valid ? "error" : "default"}
+                                />
+                                {ipAddress && !ipValidation.valid && (
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">
+                                                {ipValidation.message}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                )}
+                                {(!ipAddress || ipValidation.valid) && (
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem>
+                                                {_("Default: 10.42.0.1")}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                )}
+                            </FormGroup>
 
-                <FormGroup label={_("Subnet Prefix")} fieldId={idPrefix + "-prefix-input"}>
-                    <TextInput
-                        id={idPrefix + "-prefix-input"}
-                        type="number"
-                        value={prefix}
-                        onChange={(_, val) => setPrefix(val)}
-                        min="1"
-                        max="32"
-                    />
-                    <FormHelperText>
-                        <HelperText>
-                            <HelperTextItem>
-                                {_("Default: 24 (255.255.255.0, supports 254 clients)")}
-                            </HelperTextItem>
-                        </HelperText>
-                    </FormHelperText>
-                </FormGroup>
+                            <FormGroup label={_("Subnet Prefix")} fieldId={idPrefix + "-prefix-input"}>
+                                <TextInput
+                                id={idPrefix + "-prefix-input"}
+                                type="number"
+                                value={prefix}
+                                onChange={(_, val) => setPrefix(val)}
+                                min="1"
+                                max="32"
+                                />
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem>
+                                            {_("Default: 24 (255.255.255.0, supports 254 clients)")}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            </FormGroup>
+                        </>
+                    )}
             </Form>
         </NetworkModal>
     );


### PR DESCRIPTION
Unit 5 of the **AP network integration mode** feature (tracking: halos-org/cockpit#79). Adds the dialog half: `WiFiAPDialog` now lets the user choose **Isolated** vs **Bridged**, with mode-appropriate fields.

Closes #82.

## What's included

- **Mode selector.** A "Network mode" `<select>` seeded from the classifier (Isolated on create), placed above the fields it governs. Only the two managed modes are offered — Custom never reaches this dialog (Configure is suppressed for it, PR #84).
- **Conditional fields (R6/R7).** Isolated keeps IP Address / Subnet Prefix and emits `ipv4.method=shared`. Bridged hides them, shows an inline gateway explanation (never blank), and emits **no `ipv4`/`ipv6`** in all save branches — so the dialog can never write the `10.42.0.x` range for a bridged AP. The actual enslave onto `br0` is Unit 6 (#83).
- **Fixed channel (R3).** Bridged drops "Automatic" from the channel list, picks a band default when entering from Automatic (2.4 GHz ch 6 / 5 GHz ch 36), keeps the DFS-free 5 GHz list, and blocks submit on `channel===0` with a field message. Band/mode changes normalize the channel to one valid for the band.
- **Pre-switch warning (R8).** An inline warning appears when the selected mode differs from the AP's current mode.

## Design

The mode's decision logic is extracted as pure exports in `ap-integration-mode.js` — `apModeIpv4Settings`, `apModeNormalizeChannel`, `isApModeChannelValid`, plus the shared channel lists — so the JSX is a thin wiring layer and the R6/R7/R3 rules are unit-testable. This mirrors Unit 1's pure-classifier split.

## Testing

- **Pure helpers:** TDD'd in `test-wifi-hooks.js` (co-located with the classifier tests). QUnit **59 tests / 127 assertions, 0 failed** (headless Chromium); `test-wifi-components` 30/84 unchanged. eslint clean; `./build.js` compiles.
- **Dialog render coverage** (field visibility per mode, the warning, channel constraint) needs a NM model backend — this repo has **no JS render harness**, so it belongs in the Python integration test `test/verify/check-networkmanager-wifi`. Tracked in #85 alongside Unit 2's render coverage, and exercised on-device by Unit 7 (cockpit-networkmanager-halos#16).

## Sequencing

Lands on the integration `wifi` branch; not user-facing until Units 5+6 are merged and the `cockpit-networkmanager-halos` `.deb` is built (Phase D). Selecting Bridged is not fully functional until Unit 6 wires the enslave + watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
