### PR TITLE
feat(networkmanager): AP mode-switch orchestration + watchdog arming (Unit 6)

### DIFF
--- a/files.js
+++ b/files.js
@@ -89,6 +89,7 @@ const info = {
         "networkmanager/test-wifi-hooks.js",
         "networkmanager/test-wifi-components.js",
         "networkmanager/test-wifi-admin-gating.js",
+        "networkmanager/test-ap-switch.js",
 
         "shell/machines/test-machines.js",
 

--- a/pkg/networkmanager/ap-switch.js
+++ b/pkg/networkmanager/ap-switch.js
@@ -87,7 +87,10 @@ export function buildEnterBridgedScript({ apUuid, ethMac, gateway, channel }) {
         `${has(PORT)} || nmcli connection add type ethernet con-name ${PORT} ifname ${UP} ` +
             `master ${BR} connection.autoconnect yes`,
         // Down the active eth0 connection BEFORE br0 goes live (no dual-MAC).
-        `ETH_ACTIVE=$(nmcli -t -f NAME,DEVICE connection show --active | awk -F: '$2=="${UP}"{print $1; exit}')`,
+        // Query the device's connection name directly — colon-safe (nmcli -g
+        // emits the raw single value, vs -f NAME,DEVICE where awk -F: would
+        // mis-split a connection name containing a colon).
+        `ETH_ACTIVE=$(nmcli -t -g GENERAL.CONNECTION device show ${UP})`,
         `if [ -n "$ETH_ACTIVE" ] && [ "$ETH_ACTIVE" != ${shq(PORT)} ]; then ` +
             `nmcli connection modify "$ETH_ACTIVE" connection.autoconnect no; ` +
             `nmcli connection down "$ETH_ACTIVE"; fi`,
@@ -114,16 +117,27 @@ export function buildRevertCommand({ disable = false } = {}) {
     return disable ? ["env", "NO_AP_UP=1", ...cmd] : cmd;
 }
 
+// Per-attempt transient unit names. Unique per switch so a rapid re-attempt
+// never collides with a prior, not-yet-collected unit; the watchdog's own flock
+// serializes the actual verdict/revert.
+export function apSwitchUnitNames(tag) {
+    return {
+        deadman: `ap-bridge-switch-deadman-${tag}`,
+        apply: `ap-bridge-switch-apply-${tag}`,
+    };
+}
+
 /**
  * Arm the transient deadman that verifies the switch and reverts if it failed.
  * Detached + PID-1-owned so it survives the session drop the switch causes.
- * @param {object} [o]
+ * @param {object} o
+ * @param {string} o.tag - unique per-attempt tag (see apSwitchUnitNames)
  * @param {number} [o.window] - seconds until the verdict fires
  * @returns {string[]} argv for cockpit.spawn
  */
-export function buildArmDeadmanCommand({ window = SWITCH_DEADMAN_WINDOW } = {}) {
+export function buildArmDeadmanCommand({ tag, window = SWITCH_DEADMAN_WINDOW }) {
     return [
-        "systemd-run", "--collect", "--unit=ap-bridge-switch-deadman",
+        "systemd-run", "--collect", `--unit=${apSwitchUnitNames(tag).deadman}`,
         `--on-active=${window}`,
         AP_SWITCH_PATHS.watchdog, "switch",
     ];
@@ -133,11 +147,12 @@ export function buildArmDeadmanCommand({ window = SWITCH_DEADMAN_WINDOW } = {}) 
  * Launch the enter-Bridged apply detached so it completes across the session
  * drop. The deadman (armed separately, first) is the safety net.
  * @param {string} script - from buildEnterBridgedScript
+ * @param {string} tag - unique per-attempt tag (see apSwitchUnitNames)
  * @returns {string[]} argv for cockpit.spawn
  */
-export function buildLaunchApplyCommand(script) {
+export function buildLaunchApplyCommand(script, tag) {
     return [
-        "systemd-run", "--collect", "--unit=ap-bridge-switch-apply",
+        "systemd-run", "--collect", `--unit=${apSwitchUnitNames(tag).apply}`,
         "/bin/bash", "-c", script,
     ];
 }
@@ -165,8 +180,11 @@ export function mapVerdictToOutcome(verdict, reason) {
             ? { phase: "success-isolated", variant: "success" }
             : { phase: "auto-revert", variant: "warning" };
     case "recovered":
-    case "stranded":
         return { phase: "hard-failure", variant: "danger" };
+    case "stranded":
+        // The automatic recovery itself failed: NOT guaranteed at 10.42.0.1, so
+        // this gets its own, more defensive copy than "recovered".
+        return { phase: "stranded", variant: "danger" };
     default:
         return { phase: "idle", variant: null };
     }

--- a/pkg/networkmanager/ap-switch.js
+++ b/pkg/networkmanager/ap-switch.js
@@ -1,0 +1,188 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2026 Hat Labs
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * AP network-integration-mode switch orchestration (Unit 6, halos-org/cockpit#79).
+ *
+ * Pure logic with no React/cockpit dependencies so the command sequences are
+ * unit-testable. The actual execution (cockpit.spawn, detached systemd-run,
+ * breadcrumb polling) lives in wifi.jsx. The forward (enter-Bridged) sequence is
+ * built here; the revert is the SHARED primitive shipped device-side as
+ * ap-bridge-watchdog.sh (Unit 4), so switch-back and disable-while-Bridged just
+ * invoke that one script — never a second JS reimplementation.
+ *
+ * @module ap-switch
+ */
+
+// Device-side paths shipped by cockpit-networkmanager-halos (Unit 4).
+export const AP_SWITCH_PATHS = {
+    watchdog: "/usr/libexec/halos/ap-bridge-watchdog.sh",
+    breadcrumb: "/run/halos/ap-bridge-watchdog.verdict",
+    stateDir: "/var/lib/halos/ap-bridge",
+    expectedGwFile: "/var/lib/halos/ap-bridge/expected-gateway",
+};
+
+export const MANAGED_BRIDGE = "br0";
+export const MANAGED_BRIDGE_PORT = "br0-eth0";
+export const MANAGED_UPLINK = "eth0";
+export const MANAGED_ETH_CON = "halos-eth0"; // fixed-id standalone DHCP eth0 profile
+
+// Deadman / verdict windows (s). Conservative; tuned on hardware in Unit 7.
+export const SWITCH_DEADMAN_WINDOW = 45;
+
+/**
+ * Build the enter-Bridged apply as a single bash script, run DETACHED (the
+ * switch moves L3 off eth0 and re-associates the AP, dropping the Cockpit
+ * session; the script must finish regardless). `set -e` stops on the first
+ * failure so a partial switch is left for the armed watchdog to revert.
+ *
+ * Ordering invariants (hardware-verified recipe, halos-org/cockpit#79):
+ *  - the active eth0 connection is brought DOWN before br0 (cloned MAC) goes
+ *    live, so the cloned MAC is never on two interfaces at once;
+ *  - the AP is enslaved with NO ipv4.* in the same call (NM rejects it);
+ *  - the fixed channel is set before, and the AP con-up is, last.
+ * Every create is existence-guarded (idempotent).
+ *
+ * @param {object} o
+ * @param {string} o.apUuid   - the AP connection uuid (operate by uuid, never wlan0/STA)
+ * @param {string} o.ethMac   - eth0 permanent MAC to clone onto br0 (lease continuity)
+ * @param {string} o.gateway  - eth0's pre-switch upstream gateway (persisted for the verdict)
+ * @param {number} o.channel  - fixed channel (R3)
+ * @returns {string}
+ */
+export function buildEnterBridgedScript({ apUuid, ethMac, gateway, channel }) {
+    const BR = MANAGED_BRIDGE;
+    const PORT = MANAGED_BRIDGE_PORT;
+    const UP = MANAGED_UPLINK;
+    const { breadcrumb, stateDir, expectedGwFile } = AP_SWITCH_PATHS;
+    const has = name => `nmcli -t -f NAME connection show | grep -qx ${shq(name)}`;
+    return [
+        "set -e",
+        // Persist the pre-switch gateway for the switch-mode verdict, and mark
+        // the card in-flight before anything moves.
+        `mkdir -p ${shq(stateDir)} $(dirname ${shq(breadcrumb)})`,
+        `printf '%s\\n' ${shq(gateway)} > ${shq(expectedGwFile)}`,
+        `printf 'verdict=switching\\nreason=enter-bridged\\n' > ${shq(breadcrumb)}`,
+        // br0 with the cloned eth0 MAC (not yet up).
+        `${has(BR)} || nmcli connection add type bridge con-name ${BR} ifname ${BR} ` +
+            `ipv4.method auto ipv6.method auto bridge.stp no connection.autoconnect yes ` +
+            `bridge.mac-address ${shq(ethMac)}`,
+        // eth0 as a bridge port.
+        `${has(PORT)} || nmcli connection add type ethernet con-name ${PORT} ifname ${UP} ` +
+            `master ${BR} connection.autoconnect yes`,
+        // Down the active eth0 connection BEFORE br0 goes live (no dual-MAC).
+        `ETH_ACTIVE=$(nmcli -t -f NAME,DEVICE connection show --active | awk -F: '$2=="${UP}"{print $1; exit}')`,
+        `if [ -n "$ETH_ACTIVE" ] && [ "$ETH_ACTIVE" != ${shq(PORT)} ]; then ` +
+            `nmcli connection modify "$ETH_ACTIVE" connection.autoconnect no; ` +
+            `nmcli connection down "$ETH_ACTIVE"; fi`,
+        // Bring the bridge up (br0 holds the cloned-MAC lease).
+        `nmcli connection up ${BR}`,
+        `nmcli connection up ${PORT}`,
+        // Enslave the AP — membership only, no ipv4.* in this call.
+        `nmcli connection modify ${shq(apUuid)} connection.master ${BR} connection.slave-type bridge`,
+        // Fixed channel (R3), then bring the AP up last.
+        `nmcli connection modify ${shq(apUuid)} 802-11-wireless.channel ${shq(String(channel))}`,
+        `nmcli connection up ${shq(apUuid)}`,
+    ].join("\n");
+}
+
+/**
+ * The shared revert primitive: invoke the device-side watchdog's `revert` mode.
+ * disable-while-Bridged leaves the AP down via NO_AP_UP=1.
+ * @param {object} [o]
+ * @param {boolean} [o.disable] - disable-while-Bridged (leave the AP down)
+ * @returns {string[]} argv for cockpit.spawn
+ */
+export function buildRevertCommand({ disable = false } = {}) {
+    const cmd = [AP_SWITCH_PATHS.watchdog, "revert"];
+    return disable ? ["env", "NO_AP_UP=1", ...cmd] : cmd;
+}
+
+/**
+ * Arm the transient deadman that verifies the switch and reverts if it failed.
+ * Detached + PID-1-owned so it survives the session drop the switch causes.
+ * @param {object} [o]
+ * @param {number} [o.window] - seconds until the verdict fires
+ * @returns {string[]} argv for cockpit.spawn
+ */
+export function buildArmDeadmanCommand({ window = SWITCH_DEADMAN_WINDOW } = {}) {
+    return [
+        "systemd-run", "--collect", "--unit=ap-bridge-switch-deadman",
+        `--on-active=${window}`,
+        AP_SWITCH_PATHS.watchdog, "switch",
+    ];
+}
+
+/**
+ * Launch the enter-Bridged apply detached so it completes across the session
+ * drop. The deadman (armed separately, first) is the safety net.
+ * @param {string} script - from buildEnterBridgedScript
+ * @returns {string[]} argv for cockpit.spawn
+ */
+export function buildLaunchApplyCommand(script) {
+    return [
+        "systemd-run", "--collect", "--unit=ap-bridge-switch-apply",
+        "/bin/bash", "-c", script,
+    ];
+}
+
+/**
+ * Map a verdict breadcrumb to an R19 UI outcome. Drives the in-flight state and
+ * the success / auto-revert / hard-failure Alerts.
+ *
+ * `reason` disambiguates verdict=reverted: an intentional switch-back to Isolated
+ * (the watchdog's `revert` mode) writes reason=explicit-revert and is a SUCCESS,
+ * whereas a failed-Bridged auto-revert writes a failure reason and is a warning.
+ *
+ * @param {string} verdict - the breadcrumb `verdict` value
+ * @param {string} [reason] - the breadcrumb `reason` value
+ * @returns {{phase: string, variant: string|null}}
+ */
+export function mapVerdictToOutcome(verdict, reason) {
+    switch (verdict) {
+    case "switching":
+        return { phase: "in-flight", variant: "info" };
+    case "healthy":
+        return { phase: "success-bridged", variant: "success" };
+    case "reverted":
+        return reason === "explicit-revert"
+            ? { phase: "success-isolated", variant: "success" }
+            : { phase: "auto-revert", variant: "warning" };
+    case "recovered":
+    case "stranded":
+        return { phase: "hard-failure", variant: "danger" };
+    default:
+        return { phase: "idle", variant: null };
+    }
+}
+
+/** Parse a `key=value\n…` breadcrumb into an object. */
+export function parseBreadcrumb(text) {
+    const out = {};
+    for (const line of String(text || "").split("\n")) {
+        const i = line.indexOf("=");
+        if (i > 0) out[line.slice(0, i)] = line.slice(i + 1);
+    }
+    return out;
+}
+
+// Minimal single-quote shell escaping for values interpolated into the script.
+function shq(value) {
+    return `'${String(value).replace(/'/g, "'\\''")}'`;
+}

--- a/pkg/networkmanager/test-ap-switch.js
+++ b/pkg/networkmanager/test-ap-switch.js
@@ -82,6 +82,15 @@ QUnit.test("uses set -e so a partial switch stops for the watchdog to revert", f
     assert.ok(buildEnterBridgedScript(SAMPLE).startsWith("set -e"), "set -e first");
 });
 
+QUnit.test("shell-escapes interpolated values — a quote-breakout payload stays contained", function(assert) {
+    const s = buildEnterBridgedScript({ ...SAMPLE, gateway: "x'; touch /pwned #" });
+    // The canonical single-quote escape (' -> '\'') keeps the whole payload as a
+    // single-quoted literal, so "; touch" can never become a command.
+    assert.ok(s.includes("'x'\\''; touch /pwned #'"), "payload escaped into a single-quoted literal");
+    // It must NOT appear backslash-escaped (the vulnerable alternative) or raw.
+    assert.notOk(s.includes("x\\'; touch"), "not naively backslash-escaped");
+});
+
 QUnit.module("buildRevertCommand");
 
 QUnit.test("switch-back invokes the shared watchdog revert", function(assert) {
@@ -96,16 +105,18 @@ QUnit.test("disable-while-Bridged leaves the AP down via NO_AP_UP", function(ass
 QUnit.module("buildArmDeadmanCommand / buildLaunchApplyCommand");
 
 QUnit.test("deadman is a detached systemd-run firing the watchdog switch verdict", function(assert) {
-    const argv = buildArmDeadmanCommand({ window: 45 });
+    const argv = buildArmDeadmanCommand({ tag: "t1", window: 45 });
     assert.strictEqual(argv[0], "systemd-run");
     assert.ok(argv.includes("--on-active=45"), "window set");
     assert.ok(argv.includes("--collect"), "detached/collected");
+    assert.ok(argv.includes("--unit=ap-bridge-switch-deadman-t1"), "per-attempt unit name");
     assert.deepEqual(argv.slice(-2), [AP_SWITCH_PATHS.watchdog, "switch"], "fires watchdog switch");
 });
 
-QUnit.test("apply launches detached via systemd-run bash -c", function(assert) {
-    const argv = buildLaunchApplyCommand("set -e\nnmcli ...");
+QUnit.test("apply launches detached via systemd-run bash -c with a per-attempt unit", function(assert) {
+    const argv = buildLaunchApplyCommand("set -e\nnmcli ...", "t1");
     assert.strictEqual(argv[0], "systemd-run");
+    assert.ok(argv.includes("--unit=ap-bridge-switch-apply-t1"), "per-attempt unit name");
     assert.deepEqual(argv.slice(-3, -1), ["/bin/bash", "-c"]);
     assert.strictEqual(argv[argv.length - 1], "set -e\nnmcli ...");
 });
@@ -116,7 +127,7 @@ QUnit.test("maps each verdict to its R19 phase/variant", function(assert) {
     assert.deepEqual(mapVerdictToOutcome("switching"), { phase: "in-flight", variant: "info" });
     assert.deepEqual(mapVerdictToOutcome("healthy"), { phase: "success-bridged", variant: "success" });
     assert.deepEqual(mapVerdictToOutcome("recovered"), { phase: "hard-failure", variant: "danger" });
-    assert.deepEqual(mapVerdictToOutcome("stranded"), { phase: "hard-failure", variant: "danger" });
+    assert.deepEqual(mapVerdictToOutcome("stranded"), { phase: "stranded", variant: "danger" });
     assert.deepEqual(mapVerdictToOutcome("skipped"), { phase: "idle", variant: null });
 });
 

--- a/pkg/networkmanager/test-ap-switch.js
+++ b/pkg/networkmanager/test-ap-switch.js
@@ -1,0 +1,139 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2026 Hat Labs
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Unit tests for the AP mode-switch orchestration command builders (Unit 6).
+ */
+
+import QUnit from "qunit-tests";
+import {
+    buildEnterBridgedScript, buildRevertCommand, buildArmDeadmanCommand,
+    buildLaunchApplyCommand, mapVerdictToOutcome, parseBreadcrumb,
+    AP_SWITCH_PATHS,
+} from "./ap-switch";
+
+const SAMPLE = { apUuid: "ap-uuid-1", ethMac: "DC:A6:32:00:11:22", gateway: "192.168.8.1", channel: 6 };
+
+QUnit.module("buildEnterBridgedScript");
+
+QUnit.test("brings the active eth0 down BEFORE br0 (cloned MAC) goes live", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    const ethDown = s.indexOf('connection down "$ETH_ACTIVE"');
+    const br0Up = s.indexOf("nmcli connection up br0");
+    assert.ok(ethDown > -1 && br0Up > -1, "both steps present");
+    assert.ok(ethDown < br0Up, "eth0 down precedes br0 up (no dual-MAC)");
+});
+
+QUnit.test("clones the eth0 MAC onto br0", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    assert.ok(s.includes("bridge.mac-address 'DC:A6:32:00:11:22'"), "MAC clone present");
+});
+
+QUnit.test("enslaves the AP with membership only — never ipv4 in the same call", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    const line = s.split("\n").find(l => l.includes("connection.slave-type bridge"));
+    assert.ok(line, "enslave line present");
+    assert.ok(line.includes("connection.master br0"), "sets master");
+    assert.notOk(line.includes("ipv4"), "no ipv4.* in the enslave call");
+});
+
+QUnit.test("sets the fixed channel, and brings the AP up LAST", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    const enslave = s.indexOf("connection.slave-type bridge");
+    const channel = s.indexOf("802-11-wireless.channel '6'");
+    const apUp = s.indexOf("nmcli connection up 'ap-uuid-1'");
+    assert.ok(enslave < channel, "channel set after enslave");
+    assert.ok(channel < apUp, "channel set before AP up");
+    assert.strictEqual(s.trimEnd().endsWith("nmcli connection up 'ap-uuid-1'"), true, "AP con-up is the last step");
+});
+
+QUnit.test("creates are idempotent (existence-guarded)", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    assert.ok(s.includes("grep -qx 'br0' || nmcli connection add type bridge"), "br0 guarded");
+    assert.ok(s.includes("grep -qx 'br0-eth0' || nmcli connection add type ethernet"), "br0-eth0 guarded");
+});
+
+QUnit.test("persists the expected gateway and marks the card in-flight first", function(assert) {
+    const s = buildEnterBridgedScript(SAMPLE);
+    const gw = s.indexOf("> '" + AP_SWITCH_PATHS.expectedGwFile + "'");
+    const crumb = s.indexOf("verdict=switching");
+    const firstNmcliAdd = s.indexOf("nmcli connection add");
+    assert.ok(gw > -1 && crumb > -1, "gateway + switching breadcrumb written");
+    assert.ok(gw < firstNmcliAdd && crumb < firstNmcliAdd, "both happen before any topology change");
+});
+
+QUnit.test("uses set -e so a partial switch stops for the watchdog to revert", function(assert) {
+    assert.ok(buildEnterBridgedScript(SAMPLE).startsWith("set -e"), "set -e first");
+});
+
+QUnit.module("buildRevertCommand");
+
+QUnit.test("switch-back invokes the shared watchdog revert", function(assert) {
+    assert.deepEqual(buildRevertCommand(), [AP_SWITCH_PATHS.watchdog, "revert"]);
+});
+
+QUnit.test("disable-while-Bridged leaves the AP down via NO_AP_UP", function(assert) {
+    assert.deepEqual(buildRevertCommand({ disable: true }),
+                     ["env", "NO_AP_UP=1", AP_SWITCH_PATHS.watchdog, "revert"]);
+});
+
+QUnit.module("buildArmDeadmanCommand / buildLaunchApplyCommand");
+
+QUnit.test("deadman is a detached systemd-run firing the watchdog switch verdict", function(assert) {
+    const argv = buildArmDeadmanCommand({ window: 45 });
+    assert.strictEqual(argv[0], "systemd-run");
+    assert.ok(argv.includes("--on-active=45"), "window set");
+    assert.ok(argv.includes("--collect"), "detached/collected");
+    assert.deepEqual(argv.slice(-2), [AP_SWITCH_PATHS.watchdog, "switch"], "fires watchdog switch");
+});
+
+QUnit.test("apply launches detached via systemd-run bash -c", function(assert) {
+    const argv = buildLaunchApplyCommand("set -e\nnmcli ...");
+    assert.strictEqual(argv[0], "systemd-run");
+    assert.deepEqual(argv.slice(-3, -1), ["/bin/bash", "-c"]);
+    assert.strictEqual(argv[argv.length - 1], "set -e\nnmcli ...");
+});
+
+QUnit.module("mapVerdictToOutcome");
+
+QUnit.test("maps each verdict to its R19 phase/variant", function(assert) {
+    assert.deepEqual(mapVerdictToOutcome("switching"), { phase: "in-flight", variant: "info" });
+    assert.deepEqual(mapVerdictToOutcome("healthy"), { phase: "success-bridged", variant: "success" });
+    assert.deepEqual(mapVerdictToOutcome("recovered"), { phase: "hard-failure", variant: "danger" });
+    assert.deepEqual(mapVerdictToOutcome("stranded"), { phase: "hard-failure", variant: "danger" });
+    assert.deepEqual(mapVerdictToOutcome("skipped"), { phase: "idle", variant: null });
+});
+
+QUnit.test("reverted is success for an intentional switch-back, warning for an auto-revert", function(assert) {
+    assert.deepEqual(mapVerdictToOutcome("reverted", "explicit-revert"),
+                     { phase: "success-isolated", variant: "success" });
+    assert.deepEqual(mapVerdictToOutcome("reverted", "gateway-mismatch"),
+                     { phase: "auto-revert", variant: "warning" });
+});
+
+QUnit.module("parseBreadcrumb");
+
+QUnit.test("parses key=value lines, tolerating values with '='", function(assert) {
+    assert.deepEqual(
+        parseBreadcrumb("verdict=reverted\nreason=gateway-mismatch\n"),
+        { verdict: "reverted", reason: "gateway-mismatch" });
+    assert.deepEqual(parseBreadcrumb("").verdict, undefined);
+});
+
+QUnit.start();

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -53,7 +53,7 @@ import {
 } from './ap-integration-mode';
 import {
     buildEnterBridgedScript, buildRevertCommand, buildArmDeadmanCommand, buildLaunchApplyCommand,
-    mapVerdictToOutcome, parseBreadcrumb, AP_SWITCH_PATHS,
+    apSwitchUnitNames, mapVerdictToOutcome, parseBreadcrumb, AP_SWITCH_PATHS,
 } from './ap-switch';
 
 const _ = cockpit.gettext;
@@ -502,11 +502,27 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                 const gateway = (await cockpit.spawn(
                     ["sh", "-c", "ip route show default dev eth0 | awk '/default/{print $3; exit}'"],
                     { err: "message" })).trim();
-                const script = buildEnterBridgedScript({ apUuid, ethMac, gateway, channel });
+                // Fail closed rather than half-switch on a malformed input: an
+                // empty uuid/MAC would abort the apply mid-sequence (eth0 already
+                // down, br0 up) for the watchdog to clean up. Empty gateway is OK
+                // (the verdict fail-opens on identity).
+                if (!apUuid || !/^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(ethMac)) {
+                    setDialogError(_("Cannot switch to Bridged: the AP connection or eth0 MAC could not be read."));
+                    return;
+                }
+                const script = buildEnterBridgedScript({ apUuid, ethMac, gateway, channel: apModeChannelToEmit(mode, band, channel) });
+                const tag = String(Date.now());
                 // Arm the deadman first so a stranded switch self-reverts, then
-                // apply detached so it finishes across the session drop.
-                await cockpit.spawn(buildArmDeadmanCommand({}), { superuser: "require", err: "message" });
-                await cockpit.spawn(buildLaunchApplyCommand(script), { superuser: "require", err: "message" });
+                // apply detached so it finishes across the session drop. If the
+                // apply fails to launch, disarm the deadman so it can't fire a
+                // verdict against a switch that never started.
+                await cockpit.spawn(buildArmDeadmanCommand({ tag }), { superuser: "require", err: "message" });
+                try {
+                    await cockpit.spawn(buildLaunchApplyCommand(script, tag), { superuser: "require", err: "message" });
+                } catch (ex) {
+                    await cockpit.spawn(["systemctl", "stop", `${apSwitchUnitNames(tag).deadman}.timer`], { superuser: "try" }).catch(() => {});
+                    throw ex;
+                }
             } else {
                 await cockpit.spawn(buildRevertCommand(), { superuser: "require", err: "message" });
             }
@@ -1451,6 +1467,10 @@ function apSwitchOutcomeTitle(phase) {
         return _("Reverted to Isolated because upstream connectivity was not established.");
     case "hard-failure":
         return _("Recovery forced this device back to Isolated. It should be reachable at 10.42.0.1 — please verify from the command line.");
+    case "stranded":
+        return _("Automatic recovery failed — the device may be unreachable over the network. Connect a console (or power-cycle) and check from the command line.");
+    case "in-flight-timeout":
+        return _("Network mode change is taking longer than expected — connectivity not yet confirmed. Verify from the command line.");
     default:
         return "";
     }
@@ -1467,6 +1487,7 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
     // the apply, the watchdog, and this card.
     const [switchOutcome, setSwitchOutcome] = useState(null);
     const [switchDismissed, setSwitchDismissed] = useState(false);
+    const [inFlightTimedOut, setInFlightTimedOut] = useState(false);
 
     useEffect(() => {
         const file = cockpit.file(AP_SWITCH_PATHS.breadcrumb);
@@ -1477,9 +1498,25 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
             if (outcome.phase === "idle") { setSwitchOutcome(null); return }
             setSwitchOutcome(outcome);
             if (outcome.phase !== "in-flight") setSwitchDismissed(false);
+            setInFlightTimedOut(false);
         });
         return () => file.close();
     }, []);
+
+    // Client-side backstop: if the device-side deadman never writes a terminal
+    // verdict, don't leave the card "verifying connectivity…" forever.
+    useEffect(() => {
+        if (switchOutcome?.phase !== "in-flight") return undefined;
+        const id = window.setTimeout(() => setInFlightTimedOut(true), 150000);
+        return () => window.clearTimeout(id);
+    }, [switchOutcome?.phase]);
+
+    // Dismiss a terminal outcome: clear the breadcrumb so it doesn't re-surface
+    // on a remount, and hide it immediately.
+    const dismissSwitchOutcome = () => {
+        setSwitchDismissed(true);
+        cockpit.file(AP_SWITCH_PATHS.breadcrumb, { superuser: "try" }).replace(null).catch(() => {});
+    };
 
     const settings = connection?.Settings;
     const ssid = settings?.wifi?.ssid || _("Unknown");
@@ -1511,7 +1548,7 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                     // DHCP, and leave the AP down (the watchdog verifies eth0).
                     await cockpit.spawn(buildRevertCommand({ disable: true }), { superuser: "require", err: "message" });
                     if (uuid)
-                        await cockpit.spawn(["nmcli", "connection", "modify", uuid, "connection.autoconnect", "no"], { superuser: "try", err: "message" });
+                        await cockpit.spawn(["nmcli", "connection", "modify", uuid, "connection.autoconnect", "no"], { superuser: "require", err: "message" });
                     Dialogs.close();
                     return;
                 }
@@ -1620,22 +1657,23 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                         style={{ marginBottom: "1rem" }}
                     />
                 )}
-                {/* R19: in-flight verifying state (not dismissible — transient). */}
+                {/* R19: in-flight verifying state. Not dismissible while live;
+                    demotes to a warning if no terminal verdict arrives in time. */}
                 {switchOutcome?.phase === "in-flight" && (
                     <Alert
-                        variant="info"
+                        variant={inFlightTimedOut ? "warning" : "info"}
                         isInline
-                        title={apSwitchOutcomeTitle("in-flight")}
+                        title={apSwitchOutcomeTitle(inFlightTimedOut ? "in-flight-timeout" : "in-flight")}
                         style={{ marginBottom: "1rem" }}
                     />
                 )}
-                {/* R19: distinct success / auto-revert / hard-failure outcomes. */}
+                {/* R19: distinct success / auto-revert / hard-failure / stranded outcomes. */}
                 {switchOutcome && switchOutcome.phase !== "in-flight" && !switchDismissed && (
                     <Alert
                         variant={switchOutcome.variant}
                         isInline
                         isLiveRegion
-                        actionClose={<AlertActionCloseButton onClose={() => setSwitchDismissed(true)} />}
+                        actionClose={<AlertActionCloseButton onClose={dismissSwitchOutcome} />}
                         title={apSwitchOutcomeTitle(switchOutcome.phase)}
                         style={{ marginBottom: "1rem" }}
                     />

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/index.js';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core/dist/esm/components/Alert/index.js';
 import { Badge } from '@patternfly/react-core/dist/esm/components/Badge/index.js';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
@@ -51,6 +51,10 @@ import {
     apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid, apModeChannelToEmit,
     AP_CHANNELS_24, AP_CHANNELS_5_DFS_FREE,
 } from './ap-integration-mode';
+import {
+    buildEnterBridgedScript, buildRevertCommand, buildArmDeadmanCommand, buildLaunchApplyCommand,
+    mapVerdictToOutcome, parseBreadcrumb, AP_SWITCH_PATHS,
+} from './ap-switch';
 
 const _ = cockpit.gettext;
 
@@ -486,6 +490,32 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
         }
     };
 
+    // Unit 6: a mode CHANGE on an existing AP is a switch orchestration, not a
+    // plain save. enter-Bridged runs detached (the switch drops this session) with
+    // the watchdog armed first; switch-back invokes the shared revert primitive.
+    // The card surfaces the outcome from the /run breadcrumb (R19).
+    const applyModeSwitch = async () => {
+        const apUuid = settings.connection?.uuid;
+        try {
+            if (mode === AP_INTEGRATION_MODES.BRIDGED) {
+                const ethMac = (await cockpit.spawn(["cat", "/sys/class/net/eth0/address"], { err: "message" })).trim();
+                const gateway = (await cockpit.spawn(
+                    ["sh", "-c", "ip route show default dev eth0 | awk '/default/{print $3; exit}'"],
+                    { err: "message" })).trim();
+                const script = buildEnterBridgedScript({ apUuid, ethMac, gateway, channel });
+                // Arm the deadman first so a stranded switch self-reverts, then
+                // apply detached so it finishes across the session drop.
+                await cockpit.spawn(buildArmDeadmanCommand({}), { superuser: "require", err: "message" });
+                await cockpit.spawn(buildLaunchApplyCommand(script), { superuser: "require", err: "message" });
+            } else {
+                await cockpit.spawn(buildRevertCommand(), { superuser: "require", err: "message" });
+            }
+            Dialogs.close();
+        } catch (ex) {
+            setDialogError(typeof ex === 'string' ? ex : ex.message);
+        }
+    };
+
     const onSubmit = async (ev) => {
         if (ev) {
             ev.preventDefault();
@@ -496,6 +526,11 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
             const channelMessage = !channelValid ? _("Select a fixed channel for Bridged mode") : "";
             setDialogError(ssidValidation.message || passwordValidation.message ||
                 (isBridged ? "" : ipValidation.message) || channelMessage);
+            return;
+        }
+
+        if (connection && mode !== currentMode) {
+            await applyModeSwitch();
             return;
         }
 
@@ -747,8 +782,12 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                     </Alert>
                 )}
 
-                <FormGroup label={_("Network mode")} fieldId={idPrefix + "-mode-select"}>
-                    <select
+                {/* Switching modes enslaves the existing AP onto br0, so it is an
+                    edit-only action: on create the AP does not exist yet to switch,
+                    and "Enable AP" brings up the Isolated base. */}
+                {!isCreateDialog && (
+                    <FormGroup label={_("Network mode")} fieldId={idPrefix + "-mode-select"}>
+                        <select
                         id={idPrefix + "-mode-select"}
                         className="pf-v6-c-form-control"
                         value={mode}
@@ -757,20 +796,21 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                             setMode(newMode);
                             setChannel(apModeNormalizeChannel(newMode, band, channel));
                         }}
-                    >
-                        <option value={AP_INTEGRATION_MODES.ISOLATED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.ISOLATED)}</option>
-                        <option value={AP_INTEGRATION_MODES.BRIDGED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.BRIDGED)}</option>
-                    </select>
-                    <FormHelperText>
-                        <HelperText>
-                            <HelperTextItem>
-                                {isBridged
-                                    ? _("The AP joins your LAN through the wired connection.")
-                                    : _("The AP runs its own isolated network with local DHCP.")}
-                            </HelperTextItem>
-                        </HelperText>
-                    </FormHelperText>
-                </FormGroup>
+                        >
+                            <option value={AP_INTEGRATION_MODES.ISOLATED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.ISOLATED)}</option>
+                            <option value={AP_INTEGRATION_MODES.BRIDGED}>{apIntegrationModeLabel(AP_INTEGRATION_MODES.BRIDGED)}</option>
+                        </select>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>
+                                    {isBridged
+                                        ? _("The AP joins your LAN through the wired connection.")
+                                        : _("The AP runs its own isolated network with local DHCP.")}
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    </FormGroup>
+                )}
 
                 {mode !== currentMode && (
                     <Alert
@@ -1269,7 +1309,7 @@ const WiFiSavedNetworks = ({ dev, model }) => {
 };
 
 // Disable AP Confirmation Dialog
-const DisableAPConfirmDialog = ({ ssid, onConfirm, onCancel }) => {
+const DisableAPConfirmDialog = ({ ssid, bridged, onConfirm, onCancel }) => {
     return (
         <Modal
             id="disable-ap-confirm-dialog"
@@ -1284,6 +1324,11 @@ const DisableAPConfirmDialog = ({ ssid, onConfirm, onCancel }) => {
                     <p>
                         {cockpit.format(_("Disabling the access point \"$0\" will disconnect all currently connected clients."), ssid)}
                     </p>
+                    {bridged && (
+                        <p>
+                            {_("Disabling will also remove the LAN bridge and return the wired connection to standalone DHCP.")}
+                        </p>
+                    )}
                 </Alert>
             </ModalBody>
             <ModalFooter>
@@ -1393,11 +1438,48 @@ const WiFiAPClientList = ({ iface }) => {
     );
 };
 
+// R19 outcome Alert copy, keyed on the verdict→phase mapping (ap-switch.js).
+function apSwitchOutcomeTitle(phase) {
+    switch (phase) {
+    case "in-flight":
+        return _("Applying network mode change — verifying connectivity…");
+    case "success-bridged":
+        return _("Bridged mode active. Reach this device by hostname — its address may have changed.");
+    case "success-isolated":
+        return _("Isolated mode active. The AP is on its own network at 10.42.0.1.");
+    case "auto-revert":
+        return _("Reverted to Isolated because upstream connectivity was not established.");
+    case "hard-failure":
+        return _("Recovery forced this device back to Isolated. It should be reachable at 10.42.0.1 — please verify from the command line.");
+    default:
+        return "";
+    }
+}
+
 // WiFi AP Configuration Status Component
 export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canEnableAP, onEnableAP, deviceUnavailable, isAdminGated }) => {
     const model = useContext(ModelContext);
     const Dialogs = useDialogs();
     const [error, setError] = useState(null);
+    // R19: the AP mode-switch outcome, driven by the device-side watchdog's
+    // /run breadcrumb (written by the switch apply, the deadman verdict, and the
+    // revert primitive). The breadcrumb is the single source of truth shared by
+    // the apply, the watchdog, and this card.
+    const [switchOutcome, setSwitchOutcome] = useState(null);
+    const [switchDismissed, setSwitchDismissed] = useState(false);
+
+    useEffect(() => {
+        const file = cockpit.file(AP_SWITCH_PATHS.breadcrumb);
+        file.watch(content => {
+            if (!content) { setSwitchOutcome(null); return }
+            const crumb = parseBreadcrumb(content);
+            const outcome = mapVerdictToOutcome(crumb.verdict, crumb.reason);
+            if (outcome.phase === "idle") { setSwitchOutcome(null); return }
+            setSwitchOutcome(outcome);
+            if (outcome.phase !== "in-flight") setSwitchDismissed(false);
+        });
+        return () => file.close();
+    }, []);
 
     const settings = connection?.Settings;
     const ssid = settings?.wifi?.ssid || _("Unknown");
@@ -1422,8 +1504,18 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
 
         const doDisable = async () => {
             try {
-                // Persist the disabled state so the AP doesn't restart on reboot
                 const uuid = settings?.connection?.uuid;
+                if (integrationMode === AP_INTEGRATION_MODES.BRIDGED) {
+                    // Disable-while-Bridged is the shared revert primitive minus
+                    // re-activating the AP: tear down br0, return eth0 to standalone
+                    // DHCP, and leave the AP down (the watchdog verifies eth0).
+                    await cockpit.spawn(buildRevertCommand({ disable: true }), { superuser: "require", err: "message" });
+                    if (uuid)
+                        await cockpit.spawn(["nmcli", "connection", "modify", uuid, "connection.autoconnect", "no"], { superuser: "try", err: "message" });
+                    Dialogs.close();
+                    return;
+                }
+                // Persist the disabled state so the AP doesn't restart on reboot
                 if (uuid) {
                     await cockpit.spawn(
                         ["nmcli", "connection", "modify", uuid, "connection.autoconnect", "no"],
@@ -1447,6 +1539,7 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
         Dialogs.show(
             <DisableAPConfirmDialog
                 ssid={ssid}
+                bridged={integrationMode === AP_INTEGRATION_MODES.BRIDGED}
                 onConfirm={doDisable}
                 onCancel={() => Dialogs.close()}
             />
@@ -1524,6 +1617,26 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                         variant="danger"
                         isInline
                         title={error}
+                        style={{ marginBottom: "1rem" }}
+                    />
+                )}
+                {/* R19: in-flight verifying state (not dismissible — transient). */}
+                {switchOutcome?.phase === "in-flight" && (
+                    <Alert
+                        variant="info"
+                        isInline
+                        title={apSwitchOutcomeTitle("in-flight")}
+                        style={{ marginBottom: "1rem" }}
+                    />
+                )}
+                {/* R19: distinct success / auto-revert / hard-failure outcomes. */}
+                {switchOutcome && switchOutcome.phase !== "in-flight" && !switchDismissed && (
+                    <Alert
+                        variant={switchOutcome.variant}
+                        isInline
+                        isLiveRegion
+                        actionClose={<AlertActionCloseButton onClose={() => setSwitchDismissed(true)} />}
+                        title={apSwitchOutcomeTitle(switchOutcome.phase)}
                         style={{ marginBottom: "1rem" }}
                     />
                 )}


### PR DESCRIPTION
Unit 6 of the **AP network integration mode** feature (tracking: halos-org/cockpit#79). **Phase C — highest-risk unit.** Wires the dialog's mode change to an end-to-end switch and surfaces the outcome (R19).

Closes #83 and #81.

## What's included

- **New pure module `ap-switch.js`** (no React/cockpit deps, unit-tested):
  - `buildEnterBridgedScript` — the detached apply, encoding the hardware-verified recipe + orderings: `br0` with the **cloned eth0 MAC**, the active **eth0 brought down BEFORE `br0` goes live** (no dual-MAC), the **enslave with no `ipv4.*` in the same call** (NM rejects it), the **fixed channel**, and the **AP con-up last**. Idempotent (existence-guarded) creates; `set -e` so a partial switch stops for the watchdog to revert.
  - `buildRevertCommand` — the **shared revert primitive is the device-side `ap-bridge-watchdog.sh` from Unit 4**; switch-back and disable-while-Bridged (`NO_AP_UP=1`) just invoke that one script, never a JS reimplementation.
  - `buildArmDeadmanCommand` / `buildLaunchApplyCommand` — detached `systemd-run` (PID-1-owned, survives the session drop the switch causes).
  - `mapVerdictToOutcome` / `parseBreadcrumb` — R19 mapping (reason-aware: an intentional switch-back is *success*, a failed-Bridged auto-revert is a *warning*).
- **`WiFiAPDialog`** — a mode change on an existing AP runs the orchestration (deadman armed **first**, then the apply launched detached) instead of a plain save. The mode selector is **edit-only**: create always brings up a valid Isolated AP (you can't enslave an AP that doesn't exist yet).
- **`WiFiAPConfig`** — watches the `/run` watchdog breadcrumb and renders the R19 **in-flight** state + dismissible **success / auto-revert / hard-failure** Alerts (closes #81's remaining part). `handleDisable` tears down the bridge via the shared revert (disable variant) and shows the bridge-teardown copy (R17).

The `/run` breadcrumb is the single source of truth shared by the apply, the watchdog, and the card — no extra IPC.

## Testing

- `test-ap-switch.js`: **14 tests / 32 assertions** — the ordering invariants (eth0 down before br0 up; enslave-without-ipv4; channel before AP-up; AP-up last), the MAC clone, idempotent guards, the gateway/breadcrumb-first ordering, the revert/disable commands, the deadman/apply launch, and the R19 mapping. Full QUnit suite green (`test-wifi-hooks` 64/136 unchanged). eslint clean; `./build.js` compiles.
- **On-device (Unit 7, #16)** — the empirical psk question (default path does not pre-read/re-feed; add only if con-up demands secrets), the partial-failure → watchdog-revert path, the no-duplicate-MAC interval, and the user-visible effect (a Bridged client leases from the gateway, the device stays reachable, STA on `wlan0` unaffected) are validated on hardware. Window constants are conservative starting points.

## Sequencing

Lands on the integration `wifi` branch; not user-facing until packaged into the `.deb` (Unit 7), which now ships Units 1/2/5/6 together with the device-side watchdog (Units 3/4, already merged in `cockpit-networkmanager-halos`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
