### PR TITLE
feat(networkmanager): drop AP-switch success banner

### DIFF
--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -1455,6 +1455,8 @@ const WiFiAPClientList = ({ iface }) => {
 };
 
 // R19 outcome Alert copy, keyed on the verdict→phase mapping (ap-switch.js).
+// The success-* phases are intentionally not surfaced by the card (see the
+// render gate); their copy is kept here as the canonical outcome vocabulary.
 function apSwitchOutcomeTitle(phase) {
     switch (phase) {
     case "in-flight":
@@ -1667,8 +1669,12 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                         style={{ marginBottom: "1rem" }}
                     />
                 )}
-                {/* R19: distinct success / auto-revert / hard-failure / stranded outcomes. */}
-                {switchOutcome && switchOutcome.phase !== "in-flight" && !switchDismissed && (
+                {/* R19: auto-revert / hard-failure / stranded outcomes. A normal
+                    success is NOT bannered — a deliberate switch anticipates its
+                    own result and the card already shows the new mode; only the
+                    failure/recovery outcomes carry what the card cannot. */}
+                {switchOutcome && switchOutcome.phase !== "in-flight" &&
+                    switchOutcome.variant !== "success" && !switchDismissed && (
                     <Alert
                         variant={switchOutcome.variant}
                         isInline


### PR DESCRIPTION
## Why

A successful Isolated↔Bridged switch raised a success Alert ("Bridged mode active. Reach this device by hostname — its address may have changed." / "Isolated mode active…"). On reflection that banner is noise:

- A deliberate mode switch anticipates its own result.
- The AP config card already shows the new mode, so the banner just restated visible state.
- For Bridged, the "reach by hostname / address may have changed" advice is only useful **before** the switch (in the confirm/in-flight step), not in the post-reconnect success message — by the time an operator reads it, they've already reached Cockpit, i.e. already solved reachability. The people it would help (anyone on the now-deleted `10.42.0.1`) can't see the success alert at all.

## What

Gate the terminal-outcome Alert on `variant !== "success"`, so neither success direction banners. Unchanged:

- **in-flight** "verifying connectivity…" (progress).
- **auto-revert / hard-failure / stranded** — these carry what the card can't (e.g. *why* the card shows Isolated after a failed Bridged attempt).

`mapVerdictToOutcome` and the outcome copy are untouched (kept as the canonical vocabulary); only the render gate suppresses success. No logic change, so the existing `mapVerdictToOutcome` QUnit tests still hold; render coverage is tracked separately in #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
