### PR TITLE
fix(networkmanager): round-trip wifi.channel in settings_to_nm/from_nm

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -628,6 +628,7 @@ export function NetworkManagerModel() {
                 ssid: utils.decode_nm_property(get("802-11-wireless", "ssid", [])),
                 mode: get("802-11-wireless", "mode", "infrastructure"),
                 band: get("802-11-wireless", "band"),
+                channel: get("802-11-wireless", "channel", 0),
                 hidden: get("802-11-wireless", "hidden", false),
             };
         }
@@ -817,6 +818,11 @@ export function NetworkManagerModel() {
             set("802-11-wireless", "mode", "s", settings.wifi.mode);
             if (settings.wifi.band)
                 set("802-11-wireless", "band", "s", settings.wifi.band);
+            // NM requires a band whenever channel is non-zero, so emit a fixed
+            // channel only alongside a band; otherwise clear it, so neither a
+            // missing band nor Automatic (channel 0) leaves a stale channel.
+            set("802-11-wireless", "channel", "u",
+                (settings.wifi.band && settings.wifi.channel) ? settings.wifi.channel : undefined);
             set("802-11-wireless", "hidden", "b", settings.wifi.hidden);
         } else {
             delete result["802-11-wireless"];


### PR DESCRIPTION
## Why

`settings_to_nm` wrote only `ssid`/`mode`/`band`/`hidden` for `802-11-wireless`, and `settings_from_nm` never read `channel` — so the AP dialog's **Channel** selection was silently dropped on every D-Bus save (single-mode create + edit) and always seeded back to Automatic (#87). With no channel persisted, NM auto-selects, which under some regdomains lands on **2.4 GHz ch12/13** — channels ESP32 and many other clients won't associate on.

**Field incident:** the bridged "Hurma Pi" AP on halpi ran on auto→ch13; ESP32 SensESP sensors (ais/wind) saw the SSID but couldn't associate and fell back to the upstream network. Pinning a channel fixed it (#79 / #87 evidence).

## What

Symmetric channel read/write in the shared parser (`interfaces.js`):
- **read** the channel into the wifi model (default 0 = Automatic), so edits seed the AP's real channel instead of always Automatic;
- **write** it as a `uint32` **only alongside a band** (NM rejects a non-zero channel without one), and **clear** it otherwise so switching to Automatic doesn't leave a stale fixed channel in the cloned connection.

Band/channel consistency stays the dialog's job (`apModeNormalizeChannel`/`channelsForBand`); the dual-mode nmcli create path already applied the channel and is untouched (no double-apply).

## Verification

- **QUnit regression green:** wifi-hooks (64), wifi-components (30), ap-switch (17), utils (25), admin-gating (11) — 147 tests, 0 failures.
- **On-device:** a fixed channel persists in NM and the AP comes up on it — proven on halpi.hurma (minimal firmware, STA off): pinning ch6 took effect and real ESP32 clients associated and leased via the bridge.
- **No parser unit test:** the parser is private to `NetworkManagerModel` and coupled to instance state, so a round-trip unit test would mean hoisting/exporting a central function — out of proportion to a 6-line fix (deterministic parser coverage tracked with the harness gap in #85).
- **Manual gap:** the literal browser→D-Bus→NM round-trip through the dialog isn't automatable without operator creds; covered by composition (dialog builds `wifi.channel` via tested helpers → bundle emits it → NM applies it on halpi).

## Scope

The **STA+AP single-radio channel coupling** (the AP follows the STA's channel when both share the radio, overriding any configured channel) is a separate UX concern — tracked in #92. This fix is still required and correct for STA-off / single-AP devices and same-channel STA+AP.

closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
