### PR TITLE
AP display: share default-IP constant, relabel "IP Range" → "AP address"

### DIFF
--- a/pkg/networkmanager/ap-integration-mode.js
+++ b/pkg/networkmanager/ap-integration-mode.js
@@ -43,6 +43,12 @@ const MANAGED_BRIDGE = "br0";
 const MANAGED_UPLINK = "eth0";
 const MANAGED_AP_IFACE = "wlan0ap";
 
+// The Isolated AP's default address: a local DHCP/NAT island (R6/R7). The dialog
+// default, the ghost-connection seed, and the display text must all agree, so the
+// value lives here once. Exported because those consumers span modules.
+export const MANAGED_AP_DEFAULT_IP = "10.42.0.1";
+export const MANAGED_AP_DEFAULT_PREFIX = 24;
+
 function memberInterfaceName(connection) {
     return connection?.Settings?.connection?.interface_name;
 }

--- a/pkg/networkmanager/wifi-components.jsx
+++ b/pkg/networkmanager/wifi-components.jsx
@@ -870,7 +870,7 @@ export const WiFiCard = ({ device, interfaceName }) => {
         apItems.push(
             { label: _("Clients"), value: apInfo.clientCount || "—" },
             { label: _("Security"), value: apInfo.security || "—" },
-            { label: _("IP Range"), value: apInfo.ipRange || "—" }
+            { label: _("AP address"), value: apInfo.ipRange || "—" }
         );
     }
 

--- a/pkg/networkmanager/wifi-hooks.js
+++ b/pkg/networkmanager/wifi-hooks.js
@@ -33,7 +33,7 @@ import cockpit from 'cockpit';
 
 import { ModelContext } from './model-context';
 import { decode_nm_property } from './utils';
-import { classifyApIntegrationMode, AP_INTEGRATION_MODES } from './ap-integration-mode';
+import { classifyApIntegrationMode, AP_INTEGRATION_MODES, MANAGED_AP_DEFAULT_IP, MANAGED_AP_DEFAULT_PREFIX } from './ap-integration-mode';
 
 const _ = cockpit.gettext;
 
@@ -67,7 +67,7 @@ export function apIpRangeText(mode, ipv4Settings) {
     const addr = ipv4Settings?.address_data?.[0];
     const addrText = addr ? `${addr.address}/${addr.prefix}` : null;
     if (mode === AP_INTEGRATION_MODES.ISOLATED)
-        return addrText || "10.42.0.1/24";
+        return addrText || `${MANAGED_AP_DEFAULT_IP}/${MANAGED_AP_DEFAULT_PREFIX}`;
     if (mode === AP_INTEGRATION_MODES.BRIDGED)
         return _("Leased from upstream gateway");
     // Custom, or any unknown mode, falls here: never the 10.42 default.

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -1723,7 +1723,7 @@ export const WiFiAPConfig = ({ dev, connection, activeConnection, apActive, canE
                         <DescriptionListDescription>{security}</DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
-                        <DescriptionListTerm>{_("IP Range")}</DescriptionListTerm>
+                        <DescriptionListTerm>{_("AP address")}</DescriptionListTerm>
                         <DescriptionListDescription>
                             {apIpRangeText(integrationMode, settings?.ipv4)}
                         </DescriptionListDescription>

--- a/pkg/networkmanager/wifi.jsx
+++ b/pkg/networkmanager/wifi.jsx
@@ -50,6 +50,7 @@ import {
     classifyApIntegrationMode, isManagedApMode, AP_INTEGRATION_MODES,
     apModeIpv4Settings, apModeNormalizeChannel, isApModeChannelValid, apModeChannelToEmit,
     AP_CHANNELS_24, AP_CHANNELS_5_DFS_FREE,
+    MANAGED_AP_DEFAULT_IP, MANAGED_AP_DEFAULT_PREFIX,
 } from './ap-integration-mode';
 import {
     buildEnterBridgedScript, buildRevertCommand, buildArmDeadmanCommand, buildLaunchApplyCommand,
@@ -388,8 +389,8 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
     // option (R3): an unset/Automatic channel becomes the band default.
     const [channel, setChannel] = useState(apModeNormalizeChannel(initialMode, initialBand, safeSettings.wifi?.channel || 0));
     const [hidden, setHidden] = useState(safeSettings.wifi?.hidden || false);
-    const [ipAddress, setIPAddress] = useState(safeSettings.ipv4?.address_data?.[0]?.address || "10.42.0.1");
-    const [prefix, setPrefix] = useState(safeSettings.ipv4?.address_data?.[0]?.prefix || 24);
+    const [ipAddress, setIPAddress] = useState(safeSettings.ipv4?.address_data?.[0]?.address || MANAGED_AP_DEFAULT_IP);
+    const [prefix, setPrefix] = useState(safeSettings.ipv4?.address_data?.[0]?.prefix || MANAGED_AP_DEFAULT_PREFIX);
     const [dialogError, setDialogError] = useState("");
     const [mode, setMode] = useState(initialMode);
     const isBridged = mode === AP_INTEGRATION_MODES.BRIDGED;
@@ -940,7 +941,7 @@ export const WiFiAPDialog = ({ settings, connection, dev, dualMode = false }) =>
                                     <FormHelperText>
                                         <HelperText>
                                             <HelperTextItem>
-                                                {_("Default: 10.42.0.1")}
+                                                {cockpit.format(_("Default: $0"), MANAGED_AP_DEFAULT_IP)}
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
@@ -1036,7 +1037,7 @@ export function getWiFiAPGhostSettings({ newIfaceName, dev }) {
         },
         ipv4: {
             method: "shared", // Enables DHCP server
-            address_data: [{ address: "10.42.0.1", prefix: 24 }],
+            address_data: [{ address: MANAGED_AP_DEFAULT_IP, prefix: MANAGED_AP_DEFAULT_PREFIX }],
         },
         ipv6: {
             method: "ignore",


### PR DESCRIPTION
## Why

#85 collected follow-ups deferred from #84's review — a grab-bag, not one coherent feature. Per decision, this PR lands the two small, self-contained items (Parts 3 and 4) and drops the rest, so #85 can close.

## What

**Part 4 — share the default-IP constant.** The Isolated AP default `10.42.0.1/24` was hardcoded in four sites (dialog IP/prefix state, the ghost-connection seed, the form helper text, and the `apIpRangeText` fallback). It is load-bearing for R6/R7, so those sites must agree. Consolidated into `MANAGED_AP_DEFAULT_IP` / `MANAGED_AP_DEFAULT_PREFIX` in `ap-integration-mode.js` (next to the other managed-topology identities). The value is unchanged.

**Part 3 — relabel the "IP Range" row to "AP address".** The row shows a single host (`10.42.0.1/24`) for Isolated, "Leased from upstream gateway" for Bridged, and "Externally configured" for Custom — so "Range" describes none of them. "AP address" fits all three and keeps the reachable host address visible. Applied to both surfaces that render this value: the detail card and the compact `WiFiCard`.

The two prose status sentences that mention `10.42.0.1` (the R19 outcome titles) keep the literal — they are human-readable messages, not the default-value definition.

## Dropped from #85 (out of scope, per decision)

- **Part 1** — extending the render harness (#94) to the remaining scenarios (Bridged display, mode selector, channel seeding, password validation, admin-gating).
- **Part 2** — hardening `isManagedBridgeMaster` for a UUID-form master. The issue itself notes this is **not a live bug** (the managed save path writes the interface name), only defensive hardening for a hypothetical future NM normalization.

## Verification

- `eslint` clean on the changed files.
- `node build.js networkmanager` builds the package and the qunit tests (imports/exports resolve, JSX compiles).
- The refactor produces byte-identical values, so the merged render test and `test-wifi-hooks.js` stay green; CI runs the full qunit suite as the guard.

closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
